### PR TITLE
Fix on disk suffix array lookup

### DIFF
--- a/src/AwFmCreate.c
+++ b/src/AwFmCreate.c
@@ -236,7 +236,7 @@ enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *restrict *index,
 
 	// create the file
 	returnCode =
-			awFmWriteIndexToFile(indexData, (uint8_t *)fullSequencePtr, fullSequenceLength, fastaSrc, allowFileOverwrite);
+			awFmWriteIndexToFile(indexData, (uint8_t *)fullSequencePtr, fullSequenceLength, indexFileSrc, allowFileOverwrite);
 
 
 	if(!config->keepSuffixArrayInMemory) {

--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -443,7 +443,7 @@ enum AwFmReturnCode awFmGetSuffixArrayValueFromFile(
 	memcpy(valueOut, valueBuffer, 8);
 	*valueOut >>= offset.bitOffset;
 	*valueOut |= ((uint64_t)valueBuffer[8]) << (64 - offset.bitOffset);
-	size_t bitmask = (1 << index->suffixArray.valueBitWidth) - 1;
+	size_t bitmask = ( ((size_t)1) << index->suffixArray.valueBitWidth) - 1;
 	*valueOut &= bitmask;
 	return AwFmSuccess;
 }

--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -327,10 +327,11 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 	if(indexContainsFastaVector) {
 		fseek(fileHandle, awFmGetFastaVectorFileOffset(indexData), SEEK_SET);
 		// allocate and init the fastaVector struct
-		struct FastaVector *fastaVector = malloc(sizeof(fastaVector));
+		struct FastaVector *fastaVector = malloc(sizeof(struct FastaVector));
 		if(!fastaVector) {
 			fclose(fileHandle);
 			awFmDeallocIndex(indexData);
+			return AwFmAllocationFailure;
 		}
 		enum FastaVectorReturnCode fastaVectorReturnCode = fastaVectorInit(fastaVector);
 		if(fastaVectorReturnCode == FASTA_VECTOR_ALLOCATION_FAIL) {

--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -315,7 +315,8 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 			fclose(fileHandle);
 			awFmDeallocIndex(indexData);
 			return AwFmAllocationFailure;
-		} else {
+		}
+		else {
 			elementsRead = fread(indexData->suffixArray.values, 1, compressedSuffixArrayByteLength, fileHandle);
 			if(elementsRead != compressedSuffixArrayByteLength) {
 				fclose(fileHandle);
@@ -409,8 +410,8 @@ enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *restrict co
 		// null terminate the string
 		sequenceBuffer[sequenceSegmentLength] = 0;
 		return AwFmFileReadOkay;
-
-	} else {
+	}
+	else {
 
 		return AwFmUnsupportedVersionError;
 	}
@@ -444,7 +445,7 @@ enum AwFmReturnCode awFmGetSuffixArrayValueFromFile(
 	memcpy(valueOut, valueBuffer, 8);
 	*valueOut >>= offset.bitOffset;
 	*valueOut |= ((uint64_t)valueBuffer[8]) << (64 - offset.bitOffset);
-	size_t bitmask = ( ((size_t)1) << index->suffixArray.valueBitWidth) - 1;
+	size_t bitmask = (((size_t)1) << index->suffixArray.valueBitWidth) - 1;
 	*valueOut &= bitmask;
 	return AwFmSuccess;
 }
@@ -468,7 +469,8 @@ size_t awFmGetSequenceFileOffset(const struct AwFmIndex *restrict const index) {
 size_t awFmGetSuffixArrayFileOffset(const struct AwFmIndex *restrict const index) {
 	if(index->config.storeOriginalSequence) {
 		return awFmGetSequenceFileOffset(index) + ((index->bwtLength - 1) * sizeof(char));
-	} else {
+	}
+	else {
 		return awFmGetSequenceFileOffset(index);
 	}
 }

--- a/src/AwFmKmerTable.c
+++ b/src/AwFmKmerTable.c
@@ -92,7 +92,8 @@ static inline struct AwFmSearchRange awFmNucleotidePartialKmerSeedRangeFromTable
 	if(__builtin_expect((kmer[kmerLength - 1] | 0x20) == 't', 0)) {
 		// lookup kmer from scratch
 		awFmNucleotideNonSeededSearch(index, kmer, kmerLength, &range);
-	} else {
+	}
+	else {
 
 		const uint64_t endSequenceKmerTableIndex = 0;	 // index->endSequenceKmerTableIndex;
 		const uint8_t kmerLengthInSeedTable			 = index->config.kmerLengthInSeedTable;
@@ -141,7 +142,8 @@ inline struct AwFmSearchRange awFmAminoPartialKmerSeedRangeFromTable(
 	if(__builtin_expect((kmer[kmerLength - 1] | 0x20) == 'y', 0)) {
 		// lookup kmer from scratch
 		awFmAminoNonSeededSearch(index, kmer, kmerLength, &range);
-	} else {
+	}
+	else {
 
 		const uint64_t endSequenceKmerTableIndex = 0;	 // index->endSequenceKmerTableIndex;
 		const uint8_t kmerLengthInSeedTable			 = index->config.kmerLengthInSeedTable;

--- a/src/AwFmLetter.c
+++ b/src/AwFmLetter.c
@@ -47,7 +47,8 @@ uint8_t awFmNucleotideCompressedVectorToLetterIndex(const uint8_t compressedVect
 uint8_t awFmAsciiAminoAcidToLetterIndex(const uint8_t asciiLetter) {
 	if(__builtin_expect(asciiLetter == '$', 0)) {
 		return 21;
-	} else {
+	}
+	else {
 		static const uint8_t letterEncodings[32] = {20, 0, 20, 1, 2, 3, 4, 5, 6, 7, 20, 8, 9, 10, 11, 20, 12, 13, 14, 15,
 				16, 20, 17, 18, 20, 19, 20, 20, 20, 20, 20, 20};
 		// find the index and mod (to prevent array out of bounds for weird ascii inputs)
@@ -63,7 +64,8 @@ uint8_t awFmAsciiAminoLetterSanitize(const uint8_t asciiLetter) {
 
 	if(__builtin_expect(letterIsAmbiguityChar, 0)) {
 		return 'z';
-	} else {
+	}
+	else {
 		return asciiLetter;
 	}
 }

--- a/src/AwFmParallelSearch.c
+++ b/src/AwFmParallelSearch.c
@@ -108,7 +108,8 @@ void awFmParallelSearchLocate(const struct AwFmIndex *restrict const index,
 			parallelSearchExtendKmersInBlock(index, searchList, ranges, threadBlockStartIndex, threadBlockEndIndex);
 			parallelSearchTracebackPositionLists(index, searchList, ranges, threadBlockStartIndex, threadBlockEndIndex);
 		}
-	} else {
+	}
+	else {
 		// exact duplicate of above code, without the omp pragma, so it doesn't kill performance with only 1 thread.
 		for(size_t threadBlockStartIndex = 0; threadBlockStartIndex < searchListCount;
 				threadBlockStartIndex += AW_FM_NUM_CONCURRENT_QUERIES) {
@@ -147,7 +148,8 @@ void awFmParallelSearchCount(const struct AwFmIndex *restrict const index,
 				searchList->kmerSearchData[i].count = awFmSearchRangeLength(&ranges[i - threadBlockStartIndex]);
 			}
 		}
-	} else {
+	}
+	else {
 		// exact duplicate of above code, without the omp pragma, so it doesn't kill performance with only 1 thread.
 		for(size_t threadBlockStartIndex = 0; threadBlockStartIndex < searchListCount;
 				threadBlockStartIndex += AW_FM_NUM_CONCURRENT_QUERIES) {
@@ -183,14 +185,16 @@ void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *restrict const 
 			// TODO: reimplement partial seeded search when it's implementable
 			if(kmerLength < index->config.kmerLengthInSeedTable) {
 				awFmNucleotideNonSeededSearch(index, kmerString, kmerLength, &ranges[rangesIndex]);
-			} else {
+			}
+			else {
 				ranges[rangesIndex] = awFmNucleotideKmerSeedRangeFromTable(index, kmerString, kmerLength);
 			}
-		} else {
+		}
+		else {
 			if(kmerLength < index->config.kmerLengthInSeedTable) {
 				awFmAminoNonSeededSearch(index, kmerString, kmerLength, &ranges[rangesIndex]);
-
-			} else {
+			}
+			else {
 				ranges[rangesIndex] = awFmAminoKmerSeedRangeFromTable(index, kmerString, kmerLength);
 			}
 		}
@@ -221,7 +225,8 @@ void parallelSearchExtendKmersInBlock(const struct AwFmIndex *restrict const ind
 				if(index->config.alphabetType == AwFmAlphabetNucleotide) {
 					const uint8_t queryLetterIndex = awFmAsciiNucleotideToLetterIndex(kmerString[currentQueryLetterIndex]);
 					awFmNucleotideIterativeStepBackwardSearch(index, &ranges[rangesIndex], queryLetterIndex);
-				} else {
+				}
+				else {
 					const uint8_t queryLetterIndex = awFmAsciiAminoAcidToLetterIndex(kmerString[currentQueryLetterIndex]);
 					awFmAminoIterativeStepBackwardSearch(index, &ranges[rangesIndex], queryLetterIndex);
 				}
@@ -256,7 +261,8 @@ void parallelSearchTracebackPositionLists(const struct AwFmIndex *restrict const
 					backtrace.position = awFmNucleotideBacktraceBwtPosition(index, backtrace.position);
 					backtrace.offset++;
 				}
-			} else {
+			}
+			else {
 				while(!awFmBwtPositionIsSampled(index, backtrace.position)) {
 					backtrace.position = awFmAminoBacktraceBwtPosition(index, backtrace.position);
 					backtrace.offset++;
@@ -273,7 +279,8 @@ void parallelSearchTracebackPositionLists(const struct AwFmIndex *restrict const
 bool setPositionListCount(struct AwFmKmerSearchData *restrict const searchData, uint32_t newCount) {
 	if(__builtin_expect(searchData->capacity >= newCount, 1)) {
 		searchData->count = newCount;
-	} else {
+	}
+	else {
 		const size_t newCapacity			= newCount;
 		const size_t newLengthInBytes = newCapacity * sizeof(uint64_t);
 		void *tmpPtr									= realloc(searchData->positionList, newLengthInBytes);

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -11,7 +11,8 @@ struct AwFmSearchRange awFmCreateInitialQueryRange(
 	uint8_t finalLetterIndexInQuery;
 	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
 		finalLetterIndexInQuery = awFmAsciiNucleotideToLetterIndex(query[queryLength - 1]);
-	} else {
+	}
+	else {
 		finalLetterIndexInQuery = awFmAsciiAminoAcidToLetterIndex(query[queryLength - 1]);
 	}
 
@@ -167,7 +168,8 @@ uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *restrict const in
 				backtracePosition = awFmNucleotideBacktraceBwtPosition(index, backtracePosition);
 				databaseSequenceOffset++;
 			}
-		} else {
+		}
+		else {
 			while(!awFmBwtPositionIsSampled(index, backtracePosition)) {
 				backtracePosition = awFmAminoBacktraceBwtPosition(index, backtracePosition);
 				databaseSequenceOffset++;
@@ -203,7 +205,8 @@ enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct A
 		size_t globalPosition, size_t *sequenceNumber, size_t *localSequencePosition) {
 	if(!index->fastaVector) {
 		return AwFmUnsupportedVersionError;
-	} else {
+	}
+	else {
 		if(globalPosition >= index->bwtLength) {
 			return AwFmIllegalPositionError;
 		}
@@ -216,7 +219,8 @@ enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct A
 				size_t sequenceStartPosition;
 				if(sequenceIndex == 0) {
 					sequenceStartPosition = 0;
-				} else {
+				}
+				else {
 					sequenceStartPosition = index->fastaVector->metadata.data[sequenceIndex - 1].sequenceEndPosition;
 				}
 				*sequenceNumber				 = sequenceIndex;
@@ -257,7 +261,8 @@ struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
 	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
 		bwtBlockWidth		= sizeof(struct AwFmNucleotideBlock);
 		kmerLetterIndex = awFmAsciiNucleotideToLetterIndex(kmer[kmerLetterPosition]);
-	} else {
+	}
+	else {
 		bwtBlockWidth		= sizeof(struct AwFmAminoBlock);
 		kmerLetterIndex = awFmAsciiAminoAcidToLetterIndex(kmer[kmerLetterPosition]);
 	}
@@ -273,7 +278,8 @@ struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
 			kmerLetterIndex = awFmAsciiNucleotideToLetterIndex(kmer[kmerLetterPosition]);
 			awFmNucleotideIterativeStepBackwardSearch(index, &range, kmerLetterIndex);
 		}
-	} else {
+	}
+	else {
 		while(__builtin_expect(awFmSearchRangeIsValid(&range) && (kmerLetterPosition--), 1)) {
 			kmerLetterIndex = awFmAsciiAminoAcidToLetterIndex(kmer[kmerLetterPosition]);
 			awFmAminoIterativeStepBackwardSearch(index, &range, kmerLetterIndex);

--- a/src/AwFmSuffixArray.c
+++ b/src/AwFmSuffixArray.c
@@ -137,7 +137,8 @@ enum AwFmReturnCode awFmReadPositionsFromSuffixArray(const struct AwFmIndex *res
 		}
 
 		return AwFmSuccess;
-	} else {
+	}
+	else {
 		for(size_t i = 0; i < positionArrayLength; i++) {
 			size_t indexInSuffixArray = positionArray[i] / index->config.suffixArrayCompressionRatio;
 			enum AwFmReturnCode rc		= awFmGetSuffixArrayValueFromFile(index, indexInSuffixArray, &positionArray[i]);
@@ -160,8 +161,8 @@ enum AwFmReturnCode awFmSuffixArrayReadPositionParallel(
 		size_t saValue				 = awFmGetValueFromCompressedSuffixArray(&index->suffixArray, suffixArrayPosition);
 		backtracePtr->position = (saValue + backtracePtr->offset) % index->bwtLength;
 		return AwFmSuccess;
-
-	} else {
+	}
+	else {
 		uint64_t suffixArrayPosition = backtracePtr->position / index->config.suffixArrayCompressionRatio;
 		size_t saValue;
 		enum AwFmReturnCode rc = awFmGetSuffixArrayValueFromFile(index, suffixArrayPosition, &saValue);


### PR DESCRIPTION
This merge fixes a few small bugs, mostly related to generating an index from a fasta, and storing the suffix array on disk:

1. fixed an issue where the index was overwriting the fasta that it was being generated from.
2. fixed an issue where indices built from large sequences (over 2^32 in length) returned invalid hit positions when performing locate queries while leaving the suffix array on disk.
3. fixed an issue where the component that holds the sequence and header data when built from a fasta was allocating the incorrect amount of memory. 