### PR TITLE
Fix popcount overflow bug

### DIFF
--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -372,6 +372,7 @@ void awFmParallelSearchCount(const struct AwFmIndex *restrict const index,
  *    AwFmFileReadOkay on success.
  *    AwFmFileReadFail if the file could not be read sucessfully.
  *    AwFmIllegalPositionError if the start position is not less than the end position
+ *		AwFmUnsupportedVersionError if the index was configured to not store the original sequence.
  */
 enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *restrict const index,
 		const size_t sequenceStartPosition, const size_t sequenceSegmentLength, char *const sequenceBuffer);

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -40,7 +40,7 @@ void awFmNucleotideIterativeStepBackwardSearch(
 	AwFmSimdVec256 occurrenceVector =
 			awFmMakeNucleotideOccurrenceVector(&(index->bwtBlockList.asNucleotide[blockIndex]), letter);
 
-	uint_fast8_t vectorPopcount = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
+	uint_fast16_t vectorPopcount = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 	newStartPointer += vectorPopcount + baseOccurrence;
 
 	range->startPtr = newStartPointer;
@@ -90,7 +90,7 @@ void awFmAminoIterativeStepBackwardSearch(
 	uint64_t baseOccurrence		 = index->bwtBlockList.asAmino[blockIndex].baseOccurrences[letter];
 	AwFmSimdVec256 occurrenceVector =
 			awFmMakeAminoAcidOccurrenceVector(&(index->bwtBlockList.asAmino[blockIndex]), letter);
-	uint_fast8_t vectorPopcount = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
+	uint16_t vectorPopcount = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 	uint64_t newStartPointer		= letterPrefixSum + vectorPopcount + baseOccurrence;
 
 	// prefetch the next start ptr
@@ -315,7 +315,7 @@ inline size_t awFmNucleotideBacktraceBwtPosition(
 	const AwFmSimdVec256 occurrenceVector = awFmMakeNucleotideOccurrenceVector(blockPtr, letterIndex);
 
 
-	uint8_t vectorPopcount				= AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
+	uint16_t vectorPopcount				= AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 	uint64_t backtraceBwtPosition = prefixSums[letterIndex] + baseOccurrence + vectorPopcount - 1;
 
 	return backtraceBwtPosition;
@@ -338,7 +338,7 @@ inline size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *restrict con
 	AwFmSimdVec256 occurrenceVector = awFmMakeAminoAcidOccurrenceVector(blockPtr, letterIndex);
 	const uint64_t baseOccurrence		= blockPtr->baseOccurrences[letterIndex];
 
-	const uint_fast8_t vectorPopcount		= AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
+	const uint16_t vectorPopcount		= AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 	const uint64_t backtraceBwtPosition = prefixSums[letterIndex] + baseOccurrence + vectorPopcount - 1;
 
 	return backtraceBwtPosition;

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -90,8 +90,8 @@ void awFmAminoIterativeStepBackwardSearch(
 	uint64_t baseOccurrence		 = index->bwtBlockList.asAmino[blockIndex].baseOccurrences[letter];
 	AwFmSimdVec256 occurrenceVector =
 			awFmMakeAminoAcidOccurrenceVector(&(index->bwtBlockList.asAmino[blockIndex]), letter);
-	uint16_t vectorPopcount = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
-	uint64_t newStartPointer		= letterPrefixSum + vectorPopcount + baseOccurrence;
+	uint16_t vectorPopcount	 = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
+	uint64_t newStartPointer = letterPrefixSum + vectorPopcount + baseOccurrence;
 
 	// prefetch the next start ptr
 	uint64_t newStartBlock = (newStartPointer - 1) / AW_FM_POSITIONS_PER_FM_BLOCK;
@@ -338,7 +338,7 @@ inline size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *restrict con
 	AwFmSimdVec256 occurrenceVector = awFmMakeAminoAcidOccurrenceVector(blockPtr, letterIndex);
 	const uint64_t baseOccurrence		= blockPtr->baseOccurrences[letterIndex];
 
-	const uint16_t vectorPopcount		= AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
+	const uint16_t vectorPopcount				= AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 	const uint64_t backtraceBwtPosition = prefixSums[letterIndex] + baseOccurrence + vectorPopcount - 1;
 
 	return backtraceBwtPosition;


### PR DESCRIPTION
This PR fixes an outstanding bug. In indices with extremely large runs of the same character, backtracing for that character in the last position of a block which contains nothing but that character would cause the popcount of that block to overflow. This bug created erroneous results, or caused an infinite loop. This has been addressed.