### PR TITLE
Cpp compliance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 project(
         AWFMIndex
         HOMEPAGE_URL https://github.com/TravisWheelerLab/AvxWindowFmIndex
+        LANGUAGES C  # Specify C language explicitly
 )
 
 set(CMAKE_C_STANDARD 17)
@@ -66,22 +67,24 @@ set_target_properties(
 
 target_compile_options(
         awfmindex_static
-
         PRIVATE
         -mtune=native
         -march=native
+        -mavx2
         -Wall
         -Wextra
+        ${OpenMP_C_FLAGS}
 )
 
 target_compile_options(
         awfmindex
-
         PRIVATE
         -mtune=native
         -march=native
+        -mavx2 
         -Wall
         -Wextra
+        ${OpenMP_C_FLAGS}
 )
 
 install(

--- a/src/AwFmCreate.c
+++ b/src/AwFmCreate.c
@@ -245,6 +245,10 @@ enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *_RESTRICT_ *index
 		indexData->suffixArray.values = NULL;
 	}
 
+	if(!config->storeOriginalSequence){
+		fastaVectorStringDealloc(&indexData->fastaVector->sequence); 
+	}
+
 	// set the index as an out argument.
 	*index = indexData;
 

--- a/src/AwFmCreate.c
+++ b/src/AwFmCreate.c
@@ -15,13 +15,13 @@
 
 
 /*private function prototypes*/
-void setBwtAndPrefixSums(struct AwFmIndex *restrict const index, const size_t sequenceLength,
-		const uint8_t *restrict const sequence, const uint64_t *restrict const unsampledSuffixArray);
+void setBwtAndPrefixSums(struct AwFmIndex *_RESTRICT_ const index, const size_t sequenceLength,
+		const uint8_t *_RESTRICT_ const sequence, const uint64_t *_RESTRICT_ const unsampledSuffixArray);
 
-void populateKmerSeedTable(struct AwFmIndex *restrict const index);
-
-void populateKmerSeedTableRecursive(struct AwFmIndex *restrict const index, struct AwFmSearchRange range,
+void populateKmerSeedTableRecursive(struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange range,
 		uint8_t currentKmerLength, uint64_t currentKmerIndex, uint64_t letterIndexMultiplier);
+		
+void populateKmerSeedTable(struct AwFmIndex *_RESTRICT_ const index);
 
 
 void fullSequenceSanitize(const uint8_t *const sequence, uint8_t *const sanitizedSequenceCopy,
@@ -29,9 +29,9 @@ void fullSequenceSanitize(const uint8_t *const sequence, uint8_t *const sanitize
 
 
 /*function implementations*/
-enum AwFmReturnCode awFmCreateIndex(struct AwFmIndex *restrict *index,
-		struct AwFmIndexConfiguration *restrict const config, const uint8_t *restrict const sequence,
-		const size_t sequenceLength, const char *restrict const fileSrc) {
+enum AwFmReturnCode awFmCreateIndex(struct AwFmIndex *_RESTRICT_ *index,
+		struct AwFmIndexConfiguration *_RESTRICT_ const config, const uint8_t *_RESTRICT_ const sequence,
+		const size_t sequenceLength, const char *_RESTRICT_ const fileSrc) {
 
 	// first, do a sanity check on inputs
 	if(config == NULL) {
@@ -62,7 +62,7 @@ enum AwFmReturnCode awFmCreateIndex(struct AwFmIndex *restrict *index,
 	sanitizedSequenceCopy[suffixArrayLength - 1] = '$';
 
 	// allocate the index and all internal arrays.
-	struct AwFmIndex *restrict indexData = awFmIndexAlloc(config, suffixArrayLength);
+	struct AwFmIndex *_RESTRICT_ indexData = awFmIndexAlloc(config, suffixArrayLength);
 	if(indexData == NULL) {
 		return AwFmAllocationFailure;
 	}
@@ -125,8 +125,8 @@ enum AwFmReturnCode awFmCreateIndex(struct AwFmIndex *restrict *index,
 }
 
 /*function implementations*/
-enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *restrict *index,
-		struct AwFmIndexConfiguration *restrict const config, const char *fastaSrc, const char *restrict const indexFileSrc) {
+enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *_RESTRICT_ *index,
+		struct AwFmIndexConfiguration *_RESTRICT_ const config, const char *fastaSrc, const char *_RESTRICT_ const indexFileSrc) {
 
 	// first, do a sanity check on inputs
 	if(config == NULL) {
@@ -179,7 +179,7 @@ enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *restrict *index,
 	sanitizedSequenceCopy[suffixArrayLength - 1] = '$';
 
 	// allocate the index and all internal arrays.
-	struct AwFmIndex *restrict indexData = awFmIndexAlloc(config, suffixArrayLength);
+	struct AwFmIndex *_RESTRICT_ indexData = awFmIndexAlloc(config, suffixArrayLength);
 	if(indexData == NULL) {
 		return AwFmAllocationFailure;
 	}
@@ -251,8 +251,8 @@ enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *restrict *index,
 	return returnCode;
 }
 
-void setBwtAndPrefixSums(struct AwFmIndex *restrict const index, const size_t bwtLength,
-		const uint8_t *restrict const sequence, const uint64_t *restrict const unsampledSuffixArray) {
+void setBwtAndPrefixSums(struct AwFmIndex *_RESTRICT_ const index, const size_t bwtLength,
+		const uint8_t *_RESTRICT_ const sequence, const uint64_t *_RESTRICT_ const unsampledSuffixArray) {
 	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
 		uint64_t baseOccurrences[8] = {0};
 		// baseOccurrences is length 8 because that's how long the signpost baseOccurrences in
@@ -264,7 +264,7 @@ void setBwtAndPrefixSums(struct AwFmIndex *restrict const index, const size_t bw
 			const uint8_t byteInVector										 = positionInBlock / 8;
 			const uint8_t bitInVectorByte									 = positionInBlock % 8;
 			struct AwFmNucleotideBlock *nucleotideBlockPtr = &index->bwtBlockList.asNucleotide[blockIndex];
-			uint8_t *restrict const letterBitVectorBytes	 = (uint8_t *)nucleotideBlockPtr->letterBitVectors;
+			uint8_t *_RESTRICT_ const letterBitVectorBytes	 = (uint8_t *)nucleotideBlockPtr->letterBitVectors;
 
 			if(__builtin_expect(positionInBlock == 0, 0)) {
 				// when we start a new block, copy over the base occurrences, and initialize the bit vectors
@@ -308,8 +308,8 @@ void setBwtAndPrefixSums(struct AwFmIndex *restrict const index, const size_t bw
 			const uint8_t positionInBlock														= suffixArrayPosition % AW_FM_POSITIONS_PER_FM_BLOCK;
 			const uint8_t byteInVector															= positionInBlock / 8;
 			const uint8_t bitInVectorByte														= positionInBlock % 8;
-			struct AwFmAminoBlock *restrict const aminoBlockPointer = &index->bwtBlockList.asAmino[blockIndex];
-			uint8_t *restrict const letterBitVectorBytes						= (uint8_t *)aminoBlockPointer->letterBitVectors;
+			struct AwFmAminoBlock *_RESTRICT_ const aminoBlockPointer = &index->bwtBlockList.asAmino[blockIndex];
+			uint8_t *_RESTRICT_ const letterBitVectorBytes						= (uint8_t *)aminoBlockPointer->letterBitVectors;
 
 			if(__builtin_expect(positionInBlock == 0, 0)) {
 				// when we start a new block, copy over the base occurrences, and initialize the bit vectors
@@ -347,7 +347,7 @@ void setBwtAndPrefixSums(struct AwFmIndex *restrict const index, const size_t bw
 	}
 }
 
-void populateKmerSeedTable(struct AwFmIndex *restrict const index) {
+void populateKmerSeedTable(struct AwFmIndex *_RESTRICT_ const index) {
 	const uint8_t alphabetCardinality = awFmGetAlphabetCardinality(index->config.alphabetType);
 	for(uint8_t i = 0; i < alphabetCardinality; i++) {
 		struct AwFmSearchRange range = {.startPtr = index->prefixSums[i], .endPtr = index->prefixSums[i + 1] - 1};
@@ -356,7 +356,7 @@ void populateKmerSeedTable(struct AwFmIndex *restrict const index) {
 }
 
 
-void populateKmerSeedTableRecursive(struct AwFmIndex *restrict const index, struct AwFmSearchRange range,
+void populateKmerSeedTableRecursive(struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange range,
 		uint8_t currentKmerLength, uint64_t currentKmerIndex, uint64_t letterIndexMultiplier) {
 	const uint8_t alphabetSize = awFmGetAlphabetCardinality(index->config.alphabetType);
 

--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -17,8 +17,8 @@
 static const uint8_t IndexFileFormatIdHeaderLength = 10;
 static const char IndexFileFormatIdHeader[11]			 = "AwFmIndex\n\0";
 
-enum AwFmReturnCode awFmWriteIndexToFile(struct AwFmIndex *restrict const index, const uint8_t *restrict const sequence,
-		const uint64_t sequenceLength, const char *restrict const fileSrc) {
+enum AwFmReturnCode awFmWriteIndexToFile(struct AwFmIndex *_RESTRICT_ const index, const uint8_t *_RESTRICT_ const sequence,
+		const uint64_t sequenceLength, const char *_RESTRICT_ const fileSrc) {
 	if(__builtin_expect(fileSrc == NULL, 0)) {
 		return AwFmNoFileSrcGiven;
 	}
@@ -172,7 +172,7 @@ enum AwFmReturnCode awFmWriteIndexToFile(struct AwFmIndex *restrict const index,
 
 
 enum AwFmReturnCode awFmReadIndexFromFile(
-		struct AwFmIndex *restrict *restrict index, const char *fileSrc, const bool keepSuffixArrayInMemory) {
+		struct AwFmIndex *_RESTRICT_ *_RESTRICT_ index, const char *fileSrc, const bool keepSuffixArrayInMemory) {
 
 	if(__builtin_expect(fileSrc == NULL, 0)) {
 		return AwFmNoFileSrcGiven;
@@ -184,7 +184,7 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 	}
 
 	// create a local-scope pointer for the index, when we're done we'll set the index out-arg to this pointer.
-	struct AwFmIndex *restrict indexData;
+	struct AwFmIndex *_RESTRICT_ indexData;
 
 	// read the header, and check to make sure it matches
 	char headerBuffer[IndexFileFormatIdHeaderLength + 1];
@@ -391,7 +391,7 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 }
 
 
-enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *restrict const index,
+enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *_RESTRICT_ const index,
 		const size_t sequenceStartPosition, const size_t sequenceSegmentLength, char *const sequenceBuffer) {
 
 	if(index->config.storeOriginalSequence) {
@@ -419,7 +419,7 @@ enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *restrict co
 
 
 enum AwFmReturnCode awFmGetSuffixArrayValueFromFile(
-		const struct AwFmIndex *restrict const index, const size_t positionInArray, size_t *valueOut) {
+		const struct AwFmIndex *_RESTRICT_ const index, const size_t positionInArray, size_t *valueOut) {
 
 	struct AwFmSuffixArrayOffset offset =
 			awFmGetOffsetIntoSuffixArrayByteArray(index->suffixArray.valueBitWidth, positionInArray);
@@ -451,7 +451,7 @@ enum AwFmReturnCode awFmGetSuffixArrayValueFromFile(
 }
 
 
-size_t awFmGetSequenceFileOffset(const struct AwFmIndex *restrict const index) {
+size_t awFmGetSequenceFileOffset(const struct AwFmIndex *_RESTRICT_ const index) {
 	const size_t configLength						= 12 * sizeof(uint8_t);
 	const size_t bytesPerBwtBlock				= index->config.alphabetType == AwFmAlphabetNucleotide ?
 																						sizeof(struct AwFmNucleotideBlock) :
@@ -466,7 +466,7 @@ size_t awFmGetSequenceFileOffset(const struct AwFmIndex *restrict const index) {
 }
 
 
-size_t awFmGetSuffixArrayFileOffset(const struct AwFmIndex *restrict const index) {
+size_t awFmGetSuffixArrayFileOffset(const struct AwFmIndex *_RESTRICT_ const index) {
 	if(index->config.storeOriginalSequence) {
 		return awFmGetSequenceFileOffset(index) + ((index->bwtLength - 1) * sizeof(char));
 	}
@@ -475,7 +475,7 @@ size_t awFmGetSuffixArrayFileOffset(const struct AwFmIndex *restrict const index
 	}
 }
 
-size_t awFmGetFastaVectorFileOffset(const struct AwFmIndex *restrict const index) {
+size_t awFmGetFastaVectorFileOffset(const struct AwFmIndex *_RESTRICT_ const index) {
 	size_t compressedSuffixArrayByteLength = index->suffixArray.compressedByteLength;
 	return awFmGetSuffixArrayFileOffset(index) + compressedSuffixArrayByteLength;
 }

--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -342,8 +342,7 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 		}
 
 		// free the sequence buffer in the fastaVector, since it won't be used here
-		free(fastaVector->sequence.charData);
-		fastaVector->sequence.charData = NULL;
+		fastaVectorStringDealloc(&fastaVector->sequence);
 
 		indexData->fastaVector = fastaVector;
 		size_t fastaVectorHeaderLength;

--- a/src/AwFmFile.h
+++ b/src/AwFmFile.h
@@ -30,7 +30,7 @@
  *      AwFmFileReadFail if the file could not be read sucessfully.
  */
 enum AwFmReturnCode awFmGetSuffixArrayValueFromFile(
-		const struct AwFmIndex *restrict const index, const size_t positionInArray, size_t *valueOut);
+		const struct AwFmIndex *_RESTRICT_ const index, const size_t positionInArray, size_t *valueOut);
 
 
 /*
@@ -44,7 +44,7 @@ enum AwFmReturnCode awFmGetSuffixArrayValueFromFile(
  *  Returns:
  *    Offset into the file, in bytes, where the sequence starts.
  */
-size_t awFmGetSequenceFileOffset(const struct AwFmIndex *restrict const index);
+size_t awFmGetSequenceFileOffset(const struct AwFmIndex *_RESTRICT_ const index);
 
 
 /*
@@ -58,7 +58,7 @@ size_t awFmGetSequenceFileOffset(const struct AwFmIndex *restrict const index);
  *  Returns:
  *    Offset into the file, in bytes, where the compressed suffix array starts.
  */
-size_t awFmGetSuffixArrayFileOffset(const struct AwFmIndex *restrict const index);
+size_t awFmGetSuffixArrayFileOffset(const struct AwFmIndex *_RESTRICT_ const index);
 
 
 /*
@@ -72,6 +72,6 @@ size_t awFmGetSuffixArrayFileOffset(const struct AwFmIndex *restrict const index
  *  Returns:
  *    Offset into the file, in bytes, where the FastaVector data starts, if it exists.
  */
-size_t awFmGetFastaVectorFileOffset(const struct AwFmIndex *restrict const index);
+size_t awFmGetFastaVectorFileOffset(const struct AwFmIndex *_RESTRICT_ const index);
 
 #endif /* end of include guard: AW_FM_INDEX_FILE_H */

--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -9,6 +9,13 @@
 #include "FastaVector.h"
 
 
+
+#ifdef __cplusplus
+#define _RESTRICT_ __restrict_
+#else
+#define _RESTRICT_ restrict
+#endif
+
 #ifndef AW_FM_NUM_CONCURRENT_QUERIES
 #define AW_FM_NUM_CONCURRENT_QUERIES 8
 #endif
@@ -152,9 +159,9 @@ enum AwFmReturnCode{
  *      AwFmSuffixArrayCreationFailure if an error was caused by divsufsort64 in suffix array creation.
  *      AwFmFileWriteFail if a file write failed.
  */
-enum AwFmReturnCode awFmCreateIndex(struct AwFmIndex *restrict *index,
-		struct AwFmIndexConfiguration *restrict const config, const uint8_t *restrict const sequence,
-		const size_t sequenceLength, const char *restrict const fileSrc);
+enum AwFmReturnCode awFmCreateIndex(struct AwFmIndex *_RESTRICT_ *index,
+		struct AwFmIndexConfiguration *_RESTRICT_ const config, const uint8_t *_RESTRICT_ const sequence,
+		const size_t sequenceLength, const char *_RESTRICT_ const fileSrc);
 
 
 /*
@@ -181,8 +188,8 @@ enum AwFmReturnCode awFmCreateIndex(struct AwFmIndex *restrict *index,
  *      AwFmSuffixArrayCreationFailure if an error was caused by divsufsort64 in suffix array creation.
  *      AwFmFileWriteFail if a file write failed.
  */
-enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *restrict *index,
-		struct AwFmIndexConfiguration *restrict const config, const char *fastaSrc, const char *restrict const indexFileSrc);
+enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *_RESTRICT_ *index,
+		struct AwFmIndexConfiguration *_RESTRICT_ const config, const char *fastaSrc, const char *_RESTRICT_ const indexFileSrc);
 
 
 /*
@@ -217,8 +224,8 @@ void awFmDeallocIndex(struct AwFmIndex *index);
  *      AwFmFileAlreadyExists if a file exists at the given fileSrc, but allowOverwite was false.
  *      AwFmFileWriteFail if a file write failed.
  */
-enum AwFmReturnCode awFmWriteIndexToFile(struct AwFmIndex *restrict const index, const uint8_t *restrict const sequence,
-		const uint64_t sequenceLength, const char *restrict const fileSrc);
+enum AwFmReturnCode awFmWriteIndexToFile(struct AwFmIndex *_RESTRICT_ const index, const uint8_t *_RESTRICT_ const sequence,
+		const uint64_t sequenceLength, const char *_RESTRICT_ const fileSrc);
 
 
 /*
@@ -242,7 +249,7 @@ enum AwFmReturnCode awFmWriteIndexToFile(struct AwFmIndex *restrict const index,
  *      AwFmAllocationFailure on failure to allocated the necessary memory for the index.
  */
 enum AwFmReturnCode awFmReadIndexFromFile(
-		struct AwFmIndex *restrict *restrict index, const char *fileSrc, const bool keepSuffixArrayInMemory);
+		struct AwFmIndex *_RESTRICT_ *_RESTRICT_ index, const char *fileSrc, const bool keepSuffixArrayInMemory);
 
 
 /*
@@ -280,7 +287,7 @@ struct AwFmKmerSearchList *awFmCreateKmerSearchList(const size_t capacity);
  *  Inputs:
  *    searchData:   pointer to the searchData struct to deallocate
  */
-void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *restrict const searchList);
+void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *_RESTRICT_ const searchList);
 
 
 /*
@@ -315,8 +322,8 @@ void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *restrict const searchL
  *      AwFmFileReadFail if the file could not be read sucessfully (If suffix array
 *					is stored on file, not in memory)
  */
-enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, uint8_t numThreads);
+enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads);
 
 
 /*
@@ -346,8 +353,8 @@ enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *restrict co
  *    numThreads:   How many threads to direct OpenMP to use. The best value for this argument
  *                    will likely vary from system to system. Suggested default value is 4
  */
-void awFmParallelSearchCount(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, uint8_t numThreads);
+void awFmParallelSearchCount(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads);
 
 
 /*
@@ -372,7 +379,7 @@ void awFmParallelSearchCount(const struct AwFmIndex *restrict const index,
  *    AwFmIllegalPositionError if the start position is not less than the end position
  *		AwFmUnsupportedVersionError if the index was configured to not store the original sequence.
  */
-enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *restrict const index,
+enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *_RESTRICT_ const index,
 		const size_t sequenceStartPosition, const size_t sequenceSegmentLength, char *const sequenceBuffer);
 
 
@@ -396,7 +403,7 @@ enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *restrict co
  *    in the input query.
  */
 struct AwFmSearchRange awFmCreateInitialQueryRange(
-		const struct AwFmIndex *restrict const index, const char *restrict const query, const uint8_t queryLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const query, const uint8_t queryLength);
 
 
 /*
@@ -413,7 +420,7 @@ struct AwFmSearchRange awFmCreateInitialQueryRange(
  *    letter: letter of the prefix or suffix character.
  */
 void awFmNucleotideIterativeStepBackwardSearch(
-		const struct AwFmIndex *restrict const index, struct AwFmSearchRange *restrict const range, const uint8_t letter);
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter);
 
 
 /*
@@ -430,7 +437,7 @@ void awFmNucleotideIterativeStepBackwardSearch(
  *    letter: letter of the prefix or suffix character.
  */
 void awFmAminoIterativeStepBackwardSearch(
-		const struct AwFmIndex *restrict const index, struct AwFmSearchRange *restrict const range, const uint8_t letter);
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter);
 
 
 /*
@@ -469,8 +476,8 @@ void awFmAminoIterativeStepBackwardSearch(
  *      AwFmIllegalPositionError on a suffix array position being out of bounds of
  *        the file's compressed suffix array.
  */
-uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *restrict const index,
-		const struct AwFmSearchRange *restrict const searchRange, enum AwFmReturnCode *restrict fileAccessResult);
+uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *_RESTRICT_ const index,
+		const struct AwFmSearchRange *_RESTRICT_ const searchRange, enum AwFmReturnCode *_RESTRICT_ fileAccessResult);
 
 
 /*
@@ -495,7 +502,7 @@ uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *restrict const in
  *      AwFmIllegalPositionError if the globalPosition is greater than the length of the index.
  *      AwFmUnsupportedVersionError if the version of the AwFmIndex does not support FastaVector.
  */
-enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct AwFmIndex *restrict const index,
+enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct AwFmIndex *_RESTRICT_ const index,
 		size_t globalPosition, size_t *sequenceNumber, size_t *localSequencePosition);
 
 
@@ -518,7 +525,7 @@ enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct A
  *      AwFmUnsupportedVersionError if the version of the AwFmIndex does not support FastaVector.
  */
 enum AwFmReturnCode awFmGetHeaderStringFromSequenceNumber(
-		const struct AwFmIndex *restrict const index, size_t sequenceNumber, char **headerBuffer, size_t *headerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, size_t sequenceNumber, char **headerBuffer, size_t *headerLength);
 
 
 /*

--- a/src/AwFmIndexStruct.c
+++ b/src/AwFmIndexStruct.c
@@ -8,7 +8,7 @@
 
 #define AW_FM_BWT_BYTE_ALIGNMENT 32
 
-struct AwFmIndex *awFmIndexAlloc(const struct AwFmIndexConfiguration *restrict const config, const size_t bwtLength) {
+struct AwFmIndex *awFmIndexAlloc(const struct AwFmIndexConfiguration *_RESTRICT_ const config, const size_t bwtLength) {
 
 	// allocate the index
 	struct AwFmIndex *index = malloc(sizeof(struct AwFmIndex));
@@ -73,7 +73,7 @@ uint_fast8_t awFmGetAlphabetCardinality(const enum AwFmAlphabetType alphabet) {
 }
 
 
-size_t awFmGetKmerTableLength(const struct AwFmIndex *restrict index) {
+size_t awFmGetKmerTableLength(const struct AwFmIndex *_RESTRICT_ index) {
 	const size_t multiplier = awFmGetAlphabetCardinality(index->config.alphabetType);
 	size_t length						= 1;
 	for(size_t i = 0; i < index->config.kmerLengthInSeedTable; i++) {
@@ -84,17 +84,17 @@ size_t awFmGetKmerTableLength(const struct AwFmIndex *restrict index) {
 }
 
 
-bool awFmBwtPositionIsSampled(const struct AwFmIndex *restrict const index, const uint64_t position) {
+bool awFmBwtPositionIsSampled(const struct AwFmIndex *_RESTRICT_ const index, const uint64_t position) {
 	return (position % index->config.suffixArrayCompressionRatio) == 0;
 }
 
 
-uint64_t awFmGetCompressedSuffixArrayLength(const struct AwFmIndex *restrict const index) {
+uint64_t awFmGetCompressedSuffixArrayLength(const struct AwFmIndex *_RESTRICT_ const index) {
 	return 1 + ((index->bwtLength - 1) / index->config.suffixArrayCompressionRatio);
 }
 
 
-bool awFmSearchRangeIsValid(const struct AwFmSearchRange *restrict const searchRange) {
+bool awFmSearchRangeIsValid(const struct AwFmSearchRange *_RESTRICT_ const searchRange) {
 	return searchRange->startPtr <= searchRange->endPtr;
 }
 
@@ -124,7 +124,7 @@ uint_fast8_t awFmGetBlockQueryPositionFromGlobalPosition(const size_t globalQuer
 }
 
 
-size_t awFmSearchRangeLength(const struct AwFmSearchRange *restrict const range) {
+size_t awFmSearchRangeLength(const struct AwFmSearchRange *_RESTRICT_ const range) {
 	uint64_t length = range->endPtr - range->startPtr;
 	return (range->startPtr <= range->endPtr) ? length + 1 : 0;
 }
@@ -135,7 +135,7 @@ bool awFmIndexIsVersionValid(const uint16_t versionNumber) {
 }
 
 
-bool awFmIndexContainsFastaVector(const struct AwFmIndex *restrict const index) {
+bool awFmIndexContainsFastaVector(const struct AwFmIndex *_RESTRICT_ const index) {
 	return index->featureFlags & (1 << AW_FM_FEATURE_FLAG_BIT_FASTA_VECTOR);
 }
 

--- a/src/AwFmIndexStruct.h
+++ b/src/AwFmIndexStruct.h
@@ -24,7 +24,7 @@
  *    Allocated AwFmIndex struct, or NULL on an allocation failure.
  *      If any dynamic allocation fails, all data used in the AwFmIndex will be deallocated, too.
  */
-struct AwFmIndex *awFmIndexAlloc(const struct AwFmIndexConfiguration *restrict const config, const size_t bwtLength);
+struct AwFmIndex *awFmIndexAlloc(const struct AwFmIndexConfiguration *_RESTRICT_ const config, const size_t bwtLength);
 
 /*
  * Function:  awFmGetAlphabetCardinality
@@ -54,7 +54,7 @@ uint_fast8_t awFmGetAlphabetCardinality(const enum AwFmAlphabetType alphabet);
  *  Returns:
  *    Number of AwFmSearchRange structs in the table.
  */
-size_t awFmGetKmerTableLength(const struct AwFmIndex *restrict index);
+size_t awFmGetKmerTableLength(const struct AwFmIndex *_RESTRICT_ index);
 
 
 /*
@@ -100,7 +100,7 @@ uint8_t awFmGetPrefixSumsLength(const enum AwFmAlphabetType alphabet);
  *  Returns:
  *    True if the given position is sampled in the suffix array, false otherwise.
  */
-bool awFmBwtPositionIsSampled(const struct AwFmIndex *restrict const index, const uint64_t position);
+bool awFmBwtPositionIsSampled(const struct AwFmIndex *_RESTRICT_ const index, const uint64_t position);
 
 
 /*
@@ -114,7 +114,7 @@ bool awFmBwtPositionIsSampled(const struct AwFmIndex *restrict const index, cons
  *  Returns:
  *    Number of positions in the compressed suffix array.
  */
-uint64_t awFmGetCompressedSuffixArrayLength(const struct AwFmIndex *restrict const index);
+uint64_t awFmGetCompressedSuffixArrayLength(const struct AwFmIndex *_RESTRICT_ const index);
 
 
 /*
@@ -130,7 +130,7 @@ uint64_t awFmGetCompressedSuffixArrayLength(const struct AwFmIndex *restrict con
  *  Returns:
  *    True if the search range represents a valid range of positions, or false if it represents no elements.
  */
-bool awFmSearchRangeIsValid(const struct AwFmSearchRange *restrict const searchRange);
+bool awFmSearchRangeIsValid(const struct AwFmSearchRange *_RESTRICT_ const searchRange);
 
 
 /*
@@ -185,7 +185,7 @@ uint_fast8_t awFmGetBlockQueryPositionFromGlobalPosition(const size_t globalQuer
  *    Number of positions in the given range if the range is valid (startPtr < endPtr),
  *      or 0 otherwise, as that would imply that no instances of that kmer were found.
  */
-size_t awFmSearchRangeLength(const struct AwFmSearchRange *restrict const range);
+size_t awFmSearchRangeLength(const struct AwFmSearchRange *_RESTRICT_ const range);
 
 
 /*
@@ -215,6 +215,6 @@ bool awFmIndexIsVersionValid(const uint16_t versionNumber);
  *  Returns:
  *    True if the given version contains a FastaVector struct
  */
-bool awFmIndexContainsFastaVector(const struct AwFmIndex *restrict const index);
+bool awFmIndexContainsFastaVector(const struct AwFmIndex *_RESTRICT_ const index);
 
 #endif /* end of include guard: AW_FM_INDEX_STRUCT_H */

--- a/src/AwFmKmerTable.c
+++ b/src/AwFmKmerTable.c
@@ -5,7 +5,7 @@
 
 
 struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint8_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength) {
 
 	const uint8_t kmerSeedStartPosition = kmerLength - index->config.kmerLengthInSeedTable;
 	uint64_t kmerTableIndex							= 0;
@@ -19,7 +19,7 @@ struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
 
 
 struct AwFmSearchRange awFmAminoKmerSeedRangeFromTable(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint8_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength) {
 
 	const uint8_t kmerSeedStartPosition = kmerLength - index->config.kmerLengthInSeedTable;
 	uint64_t kmerTableIndex							= 0;
@@ -82,7 +82,7 @@ that point, searching for the smaller kmers becomes much easier.
 
 */
 static inline struct AwFmSearchRange awFmNucleotidePartialKmerSeedRangeFromTable(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint8_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength) {
 
 	assert(false, "this function is unfinished, untested, and left only to be finished for future releases");
 	struct AwFmSearchRange range = {0, 0};
@@ -136,7 +136,7 @@ static inline struct AwFmSearchRange awFmNucleotidePartialKmerSeedRangeFromTable
 
 
 inline struct AwFmSearchRange awFmAminoPartialKmerSeedRangeFromTable(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint8_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength) {
 	struct AwFmSearchRange range = {0, 0};
 
 	if(__builtin_expect((kmer[kmerLength - 1] | 0x20) == 'y', 0)) {

--- a/src/AwFmKmerTable.h
+++ b/src/AwFmKmerTable.h
@@ -24,7 +24,7 @@
  *    Copy of the AwFmSearchRange containing the startPtr and endPtr for the kmer seed.
  */
 struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint8_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength);
 
 
 /*
@@ -45,7 +45,7 @@ struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
  *    Copy of the AwFmSearchRange containing the startPtr and endPtr for the kmer seed.
  */
 struct AwFmSearchRange awFmAminoKmerSeedRangeFromTable(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint8_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength);
 
 
 #endif /* end of include guard: AW_FM_KMER_TABLE_H */

--- a/src/AwFmOccurrence.c
+++ b/src/AwFmOccurrence.c
@@ -10,9 +10,9 @@
 
 
 AwFmSimdVec256 awFmMakeNucleotideOccurrenceVector(
-		const struct AwFmNucleotideBlock *restrict const blockPtr, const uint8_t letter) {
+		const struct AwFmNucleotideBlock *_RESTRICT_ const blockPtr, const uint8_t letter) {
 	// load the letter bit vectors
-	const AwFmSimdVec256 *restrict const blockVectorPtr = blockPtr->letterBitVectors;
+	const AwFmSimdVec256 *_RESTRICT_ const blockVectorPtr = blockPtr->letterBitVectors;
 	const AwFmSimdVec256 bit0Vector											= AwFmSimdVecLoad(blockVectorPtr);
 	const AwFmSimdVec256 bit1Vector											= AwFmSimdVecLoad(blockVectorPtr + 1);
 	const AwFmSimdVec256 bit2Vector											= AwFmSimdVecLoad(blockVectorPtr + 2);
@@ -48,11 +48,11 @@ AwFmSimdVec256 awFmMakeNucleotideOccurrenceVector(
  *   Vector with bits set at every position the given letter was found.
  */
 AwFmSimdVec256 awFmMakeAminoAcidOccurrenceVector(
-		const struct AwFmAminoBlock *restrict const blockPtr, const uint8_t letter) {
+		const struct AwFmAminoBlock *_RESTRICT_ const blockPtr, const uint8_t letter) {
 
 
 	// load the letter bit vectors
-	const AwFmSimdVec256 *restrict const blockVectorPtr = blockPtr->letterBitVectors;
+	const AwFmSimdVec256 *_RESTRICT_ const blockVectorPtr = blockPtr->letterBitVectors;
 	const AwFmSimdVec256 bit0Vector											= AwFmSimdVecLoad(blockVectorPtr);
 	const AwFmSimdVec256 bit1Vector											= AwFmSimdVecLoad(blockVectorPtr + 1);
 	const AwFmSimdVec256 bit2Vector											= AwFmSimdVecLoad(blockVectorPtr + 2);
@@ -109,7 +109,7 @@ AwFmSimdVec256 awFmMakeAminoAcidOccurrenceVector(
 
 
 inline void awFmBlockPrefetch(
-		const void *restrict const baseBlockListPtr, const uint64_t blockByteWidth, const uint64_t nextQueryPosition) {
+		const void *_RESTRICT_ const baseBlockListPtr, const uint64_t blockByteWidth, const uint64_t nextQueryPosition) {
 
 	const uint64_t blockIndex = awFmGetBlockIndexFromGlobalPosition(nextQueryPosition);
 	// make the blockAddress pointer as a uint8_t* to make clean and easy pointer arithmetic when defining cache line
@@ -140,7 +140,7 @@ uint8_t awFmGetNucleotideLetterAtBwtPosition(const struct AwFmNucleotideBlock *b
 	const uint8_t byteInBlock		 = localPosition / 8;
 	const uint8_t bitInBlockByte = localPosition % 8;
 
-	const uint8_t *restrict const letterBytePointer = &((uint8_t *)&blockPtr->letterBitVectors)[byteInBlock];
+	const uint8_t *_RESTRICT_ const letterBytePointer = &((uint8_t *)&blockPtr->letterBitVectors)[byteInBlock];
 	const uint8_t letterAsCompressedVector					= ((letterBytePointer[0] >> bitInBlockByte) & 1) |
 																					 ((letterBytePointer[32] >> bitInBlockByte) & 1) << 1 |
 																					 ((letterBytePointer[64] >> bitInBlockByte) & 1) << 2;
@@ -166,7 +166,7 @@ uint8_t awFmGetAminoLetterAtBwtPosition(const struct AwFmAminoBlock *blockPtr, c
 	const uint8_t byteInBlock		 = localPosition / 8;
 	const uint8_t bitInBlockByte = localPosition % 8;
 
-	const uint8_t *restrict const letterBytePointer = &((uint8_t *)&blockPtr->letterBitVectors)[byteInBlock];
+	const uint8_t *_RESTRICT_ const letterBytePointer = &((uint8_t *)&blockPtr->letterBitVectors)[byteInBlock];
 	const uint8_t letterAsCompressedVector =
 			((letterBytePointer[0] >> bitInBlockByte) & 1) | ((letterBytePointer[32] >> bitInBlockByte) & 1) << 1 |
 			((letterBytePointer[64] >> bitInBlockByte) & 1) << 2 | ((letterBytePointer[96] >> bitInBlockByte) & 1) << 3 |

--- a/src/AwFmOccurrence.h
+++ b/src/AwFmOccurrence.h
@@ -22,7 +22,7 @@
  *   Vector with bits set at every position the given letter was found.
  */
 AwFmSimdVec256 awFmMakeNucleotideOccurrenceVector(
-		const struct AwFmNucleotideBlock *restrict const blockPtr, const uint8_t letter);
+		const struct AwFmNucleotideBlock *_RESTRICT_ const blockPtr, const uint8_t letter);
 
 
 /*
@@ -39,7 +39,7 @@ AwFmSimdVec256 awFmMakeNucleotideOccurrenceVector(
  *   Vector with bits set at every position the given letter was found.
  */
 AwFmSimdVec256 awFmMakeAminoAcidOccurrenceVector(
-		const struct AwFmAminoBlock *restrict const blockPtr, const uint8_t letter);
+		const struct AwFmAminoBlock *_RESTRICT_ const blockPtr, const uint8_t letter);
 
 
 /*
@@ -83,7 +83,7 @@ uint16_t awFmVectorPopcountBuiltin(const AwFmSimdVec256 occurrenceVector, const 
  * blockList that contains the block that should be prefetched.
  */
 void awFmBlockPrefetch(
-		const void *restrict const baseBlockListPtr, const uint64_t blockByteWidth, const uint64_t nextQueryPosition);
+		const void *_RESTRICT_ const baseBlockListPtr, const uint64_t blockByteWidth, const uint64_t nextQueryPosition);
 
 
 /*

--- a/src/AwFmParallelSearch.c
+++ b/src/AwFmParallelSearch.c
@@ -18,20 +18,20 @@
 #define DEFAULT_POSITION_LIST_CAPACITY 4
 
 
-void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, struct AwFmSearchRange *restrict const ranges,
+void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, struct AwFmSearchRange *_RESTRICT_ const ranges,
 		const size_t threadBlockStartIndex, const size_t threadBlockEndIndex);
 
-void parallelSearchExtendKmersInBlock(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, struct AwFmSearchRange *restrict const ranges,
+void parallelSearchExtendKmersInBlock(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, struct AwFmSearchRange *_RESTRICT_ const ranges,
 		const size_t threadBlockStartIndex, const size_t threadBlockEndIndex);
 
-enum AwFmReturnCode parallelSearchTracebackPositionLists(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, struct AwFmSearchRange *restrict const ranges,
+enum AwFmReturnCode parallelSearchTracebackPositionLists(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, struct AwFmSearchRange *_RESTRICT_ const ranges,
 		const size_t threadBlockStartIndex, const size_t threadBlockEndIndex);
 
 
-bool setPositionListCount(struct AwFmKmerSearchData *restrict const searchData, uint32_t count);
+bool setPositionListCount(struct AwFmKmerSearchData *_RESTRICT_ const searchData, uint32_t count);
 
 
 struct AwFmKmerSearchList *awFmCreateKmerSearchList(const size_t capacity) {
@@ -80,7 +80,7 @@ struct AwFmKmerSearchList *awFmCreateKmerSearchList(const size_t capacity) {
 }
 
 
-void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *restrict const searchList) {
+void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *_RESTRICT_ const searchList) {
 	for(size_t i = 0; i < searchList->capacity; i++) {
 		free(searchList->kmerSearchData[i].positionList);
 	}
@@ -89,8 +89,8 @@ void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *restrict const searchL
 }
 
 
-enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, uint8_t numThreads) {
+enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads) {
 
 	const uint32_t searchListCount = searchList->count;
 	enum AwFmReturnCode atomicReturnCode = AwFmSuccess;
@@ -133,8 +133,8 @@ enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *restrict co
 	}
 }
 
-void awFmParallelSearchCount(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, uint8_t numThreads) {
+void awFmParallelSearchCount(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads) {
 
 	const uint32_t searchListCount = searchList->count;
 
@@ -179,8 +179,8 @@ void awFmParallelSearchCount(const struct AwFmIndex *restrict const index,
 }
 
 
-void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, struct AwFmSearchRange *restrict const ranges,
+void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, struct AwFmSearchRange *_RESTRICT_ const ranges,
 		const size_t threadBlockStartIndex, const size_t threadBlockEndIndex) {
 
 	for(size_t kmerIndex = threadBlockStartIndex; kmerIndex < threadBlockEndIndex; kmerIndex++) {
@@ -210,8 +210,8 @@ void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *restrict const 
 }
 
 
-void parallelSearchExtendKmersInBlock(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, struct AwFmSearchRange *restrict const ranges,
+void parallelSearchExtendKmersInBlock(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, struct AwFmSearchRange *_RESTRICT_ const ranges,
 		const size_t threadBlockStartIndex, const size_t threadBlockEndIndex) {
 	bool hasActiveQueries					 = true;
 	uint8_t currentKmerLetterIndex = index->config.kmerLengthInSeedTable;
@@ -222,7 +222,7 @@ void parallelSearchExtendKmersInBlock(const struct AwFmIndex *restrict const ind
 
 		for(size_t kmerIndex = threadBlockStartIndex; kmerIndex < threadBlockEndIndex; kmerIndex++) {
 			const uint64_t rangesIndex																 = kmerIndex - threadBlockStartIndex;
-			const struct AwFmKmerSearchData *restrict const searchData = &searchList->kmerSearchData[kmerIndex];
+			const struct AwFmKmerSearchData *_RESTRICT_ const searchData = &searchList->kmerSearchData[kmerIndex];
 			const uint8_t kmerLength																	 = searchData->kmerLength;
 			const char *kmerString																		 = searchData->kmerString;
 
@@ -244,8 +244,8 @@ void parallelSearchExtendKmersInBlock(const struct AwFmIndex *restrict const ind
 }
 
 
-enum AwFmReturnCode parallelSearchTracebackPositionLists(const struct AwFmIndex *restrict const index,
-		struct AwFmKmerSearchList *restrict const searchList, struct AwFmSearchRange *restrict const ranges,
+enum AwFmReturnCode parallelSearchTracebackPositionLists(const struct AwFmIndex *_RESTRICT_ const index,
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, struct AwFmSearchRange *_RESTRICT_ const ranges,
 		const size_t threadBlockStartIndex, const size_t threadBlockEndIndex) {
 
 	for(size_t kmerIndex = threadBlockStartIndex; kmerIndex < threadBlockEndIndex; kmerIndex++) {
@@ -254,7 +254,7 @@ enum AwFmReturnCode parallelSearchTracebackPositionLists(const struct AwFmIndex 
 		struct AwFmKmerSearchData *searchData = &searchList->kmerSearchData[kmerIndex];
 		const size_t rangeLength							= awFmSearchRangeLength(&ranges[rangesIndex]);
 		setPositionListCount(searchData, rangeLength);
-		// struct AwFmBacktrace *restrict const backtracePositionList = {
+		// struct AwFmBacktrace *_RESTRICT_ const backtracePositionList = {
 		//   .position = searchList->kmerSearchData[kmerIndex].positionList;
 		// };searchList->kmerSearchData[kmerIndex].positionBacktraceList;
 
@@ -287,7 +287,7 @@ enum AwFmReturnCode parallelSearchTracebackPositionLists(const struct AwFmIndex 
 }
 
 
-bool setPositionListCount(struct AwFmKmerSearchData *restrict const searchData, uint32_t newCount) {
+bool setPositionListCount(struct AwFmKmerSearchData *_RESTRICT_ const searchData, uint32_t newCount) {
 	if(__builtin_expect(searchData->capacity >= newCount, 1)) {
 		searchData->count = newCount;
 	}

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -6,7 +6,7 @@
 
 
 struct AwFmSearchRange awFmCreateInitialQueryRange(
-		const struct AwFmIndex *restrict const index, const char *restrict const query, const uint8_t queryLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const query, const uint8_t queryLength) {
 
 	uint8_t finalLetterIndexInQuery;
 	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
@@ -25,7 +25,7 @@ struct AwFmSearchRange awFmCreateInitialQueryRange(
 
 
 void awFmNucleotideIterativeStepBackwardSearch(
-		const struct AwFmIndex *restrict const index, struct AwFmSearchRange *restrict const range, const uint8_t letter) {
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter) {
 
 	// query for the start pointer
 	uint64_t queryPosition				 = range->startPtr - 1;
@@ -79,7 +79,7 @@ void awFmNucleotideIterativeStepBackwardSearch(
 
 
 void awFmAminoIterativeStepBackwardSearch(
-		const struct AwFmIndex *restrict const index, struct AwFmSearchRange *restrict const range, const uint8_t letter) {
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter) {
 
 	// query for the start pointer
 	uint64_t queryPosition				 = range->startPtr - 1;
@@ -125,8 +125,8 @@ void awFmAminoIterativeStepBackwardSearch(
 }
 
 
-uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *restrict const index,
-		const struct AwFmSearchRange *restrict const searchRange, enum AwFmReturnCode *restrict fileAccessResult) {
+uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *_RESTRICT_ const index,
+		const struct AwFmSearchRange *_RESTRICT_ const searchRange, enum AwFmReturnCode *_RESTRICT_ fileAccessResult) {
 
 	const uint64_t numPositionsInRange = awFmSearchRangeLength(searchRange);
 
@@ -136,8 +136,8 @@ uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *restrict const in
 		return NULL;
 	}
 
-	uint64_t *const restrict positionArray = malloc(numPositionsInRange * sizeof(uint64_t));
-	uint64_t *const restrict offsetArray	 = malloc(numPositionsInRange * sizeof(uint64_t));
+	uint64_t *const _RESTRICT_ positionArray = malloc(numPositionsInRange * sizeof(uint64_t));
+	uint64_t *const _RESTRICT_ offsetArray	 = malloc(numPositionsInRange * sizeof(uint64_t));
 	// check for allocation failures
 	if(__builtin_expect(positionArray == NULL, 0)) {
 		*fileAccessResult = AwFmAllocationFailure;
@@ -201,7 +201,7 @@ uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *restrict const in
 }
 
 
-enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct AwFmIndex *restrict const index,
+enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct AwFmIndex *_RESTRICT_ const index,
 		size_t globalPosition, size_t *sequenceNumber, size_t *localSequencePosition) {
 	if(!index->fastaVector) {
 		return AwFmUnsupportedVersionError;
@@ -235,7 +235,7 @@ enum AwFmReturnCode awFmGetLocalSequencePositionFromIndexPosition(const struct A
 
 
 enum AwFmReturnCode awFmGetHeaderStringFromSequenceNumber(
-		const struct AwFmIndex *restrict const index, size_t sequenceNumber, char **headerBuffer, size_t *headerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, size_t sequenceNumber, char **headerBuffer, size_t *headerLength) {
 	if(sequenceNumber > index->fastaVector->metadata.count) {
 		return AwFmIllegalPositionError;
 	}
@@ -253,7 +253,7 @@ enum AwFmReturnCode awFmGetHeaderStringFromSequenceNumber(
 
 
 struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint16_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength) {
 	int8_t kmerLetterPosition = kmerLength - 1;
 	uint16_t bwtBlockWidth;
 	uint8_t kmerLetterIndex;
@@ -290,7 +290,7 @@ struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
 
 
 bool awFmSingleKmerExists(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint16_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength) {
 
 	struct AwFmSearchRange kmerRange = awFmDatabaseSingleKmerExactMatch(index, kmer, kmerLength);
 	return kmerRange.startPtr <= kmerRange.endPtr;
@@ -298,12 +298,12 @@ bool awFmSingleKmerExists(
 
 
 inline size_t awFmNucleotideBacktraceBwtPosition(
-		const struct AwFmIndex *restrict const index, const uint64_t bwtPosition) {
+		const struct AwFmIndex *_RESTRICT_ const index, const uint64_t bwtPosition) {
 	const uint64_t *prefixSums			 = index->prefixSums;
 	const uint64_t blockIndex				 = awFmGetBlockIndexFromGlobalPosition(bwtPosition);
 	const uint8_t localQueryPosition = awFmGetBlockQueryPositionFromGlobalPosition(bwtPosition);
 
-	const struct AwFmNucleotideBlock *restrict const blockPtr = &index->bwtBlockList.asNucleotide[blockIndex];
+	const struct AwFmNucleotideBlock *_RESTRICT_ const blockPtr = &index->bwtBlockList.asNucleotide[blockIndex];
 	const uint8_t letterIndex = awFmGetNucleotideLetterAtBwtPosition(blockPtr, localQueryPosition);
 
 	// if we encountered the sentinel, we know the position and can stop backtracing
@@ -322,12 +322,12 @@ inline size_t awFmNucleotideBacktraceBwtPosition(
 }
 
 
-inline size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *restrict const index, const uint64_t bwtPosition) {
+inline size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *_RESTRICT_ const index, const uint64_t bwtPosition) {
 	const uint64_t *prefixSums			 = index->prefixSums;
 	const uint64_t blockIndex				 = awFmGetBlockIndexFromGlobalPosition(bwtPosition);
 	const uint8_t localQueryPosition = awFmGetBlockQueryPositionFromGlobalPosition(bwtPosition);
 
-	const struct AwFmAminoBlock *restrict const blockPtr = &index->bwtBlockList.asAmino[blockIndex];
+	const struct AwFmAminoBlock *_RESTRICT_ const blockPtr = &index->bwtBlockList.asAmino[blockIndex];
 	uint8_t letterIndex																	 = awFmGetAminoLetterAtBwtPosition(blockPtr, localQueryPosition);
 
 	// if we encountered the sentinel, we know the position and can stop backtracing
@@ -345,7 +345,7 @@ inline size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *restrict con
 }
 
 
-inline void awFmNucleotideNonSeededSearch(const struct AwFmIndex *restrict const index, const char *restrict const kmer,
+inline void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
 		const uint8_t kmerLength, struct AwFmSearchRange *range) {
 
 	uint8_t indexInKmerString = kmerLength - 1;
@@ -359,7 +359,7 @@ inline void awFmNucleotideNonSeededSearch(const struct AwFmIndex *restrict const
 }
 
 
-inline void awFmAminoNonSeededSearch(const struct AwFmIndex *restrict const index, const char *restrict const kmer,
+inline void awFmAminoNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
 		const uint8_t kmerLength, struct AwFmSearchRange *range) {
 
 	uint8_t indexInKmerString = kmerLength - 1;

--- a/src/AwFmSearch.h
+++ b/src/AwFmSearch.h
@@ -32,7 +32,7 @@
  *    the given kmer does not exist in the database sequence.
  */
 struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint16_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength);
 
 
 /*
@@ -50,7 +50,7 @@ struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
  *    Position in the suffix array of the character in the sequence immediately preceeding the one
  *      found at the given bwtPosition.
  */
-size_t awFmNucleotideBacktraceBwtPosition(const struct AwFmIndex *restrict const index, const uint64_t bwtPosition);
+size_t awFmNucleotideBacktraceBwtPosition(const struct AwFmIndex *_RESTRICT_ const index, const uint64_t bwtPosition);
 
 /*
  * Function:  awFmBacktraceBwtPosition
@@ -67,7 +67,7 @@ size_t awFmNucleotideBacktraceBwtPosition(const struct AwFmIndex *restrict const
  *    Position in the suffix array of the character in the sequence immediately preceeding the one
  *      found at the given bwtPosition.
  */
-size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *restrict const index, const uint64_t bwtPosition);
+size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *_RESTRICT_ const index, const uint64_t bwtPosition);
 
 /*
  * Function:  awFmSingleKmerExists
@@ -87,7 +87,7 @@ size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *restrict const inde
  *      cannot be found in the database sequence.
  */
 bool awFmSingleKmerExists(
-		const struct AwFmIndex *restrict const index, const char *restrict const kmer, const uint16_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength);
 
 /*
  * Function:  awFmNucleotideNonSeededSearch
@@ -110,7 +110,7 @@ bool awFmSingleKmerExists(
  *      Since gcc doesn't seem to perform NRVO correctly, this performs slightly better.
  *
  */
-void awFmNucleotideNonSeededSearch(const struct AwFmIndex *restrict const index, const char *restrict const kmer,
+void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
 		const uint8_t kmerLength, struct AwFmSearchRange *range);
 
 
@@ -135,7 +135,7 @@ void awFmNucleotideNonSeededSearch(const struct AwFmIndex *restrict const index,
  *      Since gcc doesn't seem to perform NRVO correctly, this performs slightly better.
  *
  */
-void awFmAminoNonSeededSearch(const struct AwFmIndex *restrict const index, const char *restrict const kmer,
+void awFmAminoNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
 		const uint8_t kmerLength, struct AwFmSearchRange *range);
 
 

--- a/src/AwFmSuffixArray.c
+++ b/src/AwFmSuffixArray.c
@@ -126,8 +126,8 @@ inline size_t awFmGetSampledSuffixArrayLength(uint64_t bwtLength, uint64_t compr
 }
 
 
-enum AwFmReturnCode awFmReadPositionsFromSuffixArray(const struct AwFmIndex *restrict const index,
-		uint64_t *restrict const positionArray, const size_t positionArrayLength) {
+enum AwFmReturnCode awFmReadPositionsFromSuffixArray(const struct AwFmIndex *_RESTRICT_ const index,
+		uint64_t *_RESTRICT_ const positionArray, const size_t positionArrayLength) {
 
 	if(index->config.keepSuffixArrayInMemory) {
 		for(size_t i = 0; i < positionArrayLength; i++) {
@@ -153,7 +153,7 @@ enum AwFmReturnCode awFmReadPositionsFromSuffixArray(const struct AwFmIndex *res
 
 
 enum AwFmReturnCode awFmSuffixArrayReadPositionParallel(
-		const struct AwFmIndex *restrict const index, struct AwFmBacktrace *restrict const backtracePtr) {
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmBacktrace *_RESTRICT_ const backtracePtr) {
 
 	if(__builtin_expect(index->config.keepSuffixArrayInMemory, 1)) {
 		uint64_t suffixArrayPosition = backtracePtr->position / index->config.suffixArrayCompressionRatio;

--- a/src/AwFmSuffixArray.h
+++ b/src/AwFmSuffixArray.h
@@ -128,7 +128,7 @@ size_t awFmGetSampledSuffixArrayLength(uint64_t bwtLength, uint64_t compressionR
  *      AwFmFileReadFail if the file could not be read sucessfully.
  */
 enum AwFmReturnCode awFmReadPositionsFromSuffixArray(
-		const struct AwFmIndex *const index, uint64_t *restrict const positionArray, const size_t positionArrayLength);
+		const struct AwFmIndex *const index, uint64_t *_RESTRICT_ const positionArray, const size_t positionArrayLength);
 
 
 struct AwFmSuffixArrayOffset awFmGetOffsetIntoSuffixArrayByteArray(
@@ -152,6 +152,6 @@ struct AwFmSuffixArrayOffset awFmGetOffsetIntoSuffixArrayByteArray(
  *      AwFmFileReadFail if the file could not be read sucessfully.
  */
 enum AwFmReturnCode awFmSuffixArrayReadPositionParallel(
-		const struct AwFmIndex *restrict const index, struct AwFmBacktrace *restrict const backtracePtr);
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmBacktrace *_RESTRICT_ const backtracePtr);
 
 #endif

--- a/test/createTests/AwFmCreationTest.c
+++ b/test/createTests/AwFmCreationTest.c
@@ -53,12 +53,12 @@ void testDisallowOverwrite();
 void testMetadataCheck();
 
 void testKmerTableLengths(
-		const struct AwFmIndex *restrict const index, const uint8_t *sequence, const size_t sequenceLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const uint8_t *sequence, const size_t sequenceLength);
 
 struct AwFmIndex *testCreateNucleotideIndex(const uint8_t *sequence, const size_t sequenceLength);
 
 void testCreateAminoIndex();
-void testPrefixSums(const struct AwFmIndex *restrict const index, const uint8_t *sequence, const size_t sequenceLength);
+void testPrefixSums(const struct AwFmIndex *_RESTRICT_ const index, const uint8_t *sequence, const size_t sequenceLength);
 
 int main(int argc, char **argv) {
 	srand(time(NULL));
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
 	// }
 	printf("\n");
 
-	struct AwFmIndex *restrict const index = testCreateNucleotideIndex(sequence, sequenceLength);
+	struct AwFmIndex *_RESTRICT_ const index = testCreateNucleotideIndex(sequence, sequenceLength);
 	testPrefixSums(index, sequence, sequenceLength);
 	testKmerTableLengths(index, sequence, sequenceLength);
 
@@ -108,7 +108,7 @@ struct AwFmIndex *testCreateNucleotideIndex(const uint8_t *sequence, const size_
 	config.storeOriginalSequence				 = false;
 
 	const uint32_t expectedVersionNumber = AW_FM_CURRENT_VERSION_NUMBER;
-	struct AwFmIndex *restrict index;
+	struct AwFmIndex *_RESTRICT_ index;
 	enum AwFmReturnCode returnCode = awFmCreateIndex(&index, &config, sequence, sequenceLength, fileSrc);
 	sprintf(buffer, "return code was not successful, returned %d", returnCode);
 	testAssertString(returnCode >= 0, buffer);
@@ -140,7 +140,7 @@ struct AwFmIndex *testCreateNucleotideIndex(const uint8_t *sequence, const size_
 
 
 void testPrefixSums(
-		const struct AwFmIndex *restrict const index, const uint8_t *sequence, const size_t sequenceLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const uint8_t *sequence, const size_t sequenceLength) {
 	const uint8_t alphabetSize = awFmGetAlphabetCardinality(index->config.alphabetType);
 	size_t *letterCounts			 = malloc((alphabetSize + 2) * sizeof(size_t));
 	memset(letterCounts, 0, alphabetSize * sizeof(size_t));
@@ -173,7 +173,7 @@ void testPrefixSums(
 
 
 void testKmerTableLengths(
-		const struct AwFmIndex *restrict const index, const uint8_t *sequence, const size_t sequenceLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const uint8_t *sequence, const size_t sequenceLength) {
 	printf("beginning kmer table lengths test\n");
 	const uint8_t kmerLength = index->config.kmerLengthInSeedTable;
 	for(size_t sequencePosition = 0; sequencePosition <= sequenceLength - kmerLength; sequencePosition++) {

--- a/test/kmerSeedTableTests/kmerSeedTableTests.c
+++ b/test/kmerSeedTableTests/kmerSeedTableTests.c
@@ -21,9 +21,9 @@ uint8_t aminoLookup[21] = {
 		'a', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'y', 'z'};
 uint8_t nucleotideLookup[5] = {'a', 'g', 'c', 't', 'x'};
 
-void checkRangeForCorrectness(const struct AwFmSearchRange *restrict const range,
-		const uint64_t *restrict const suffixArray, const char *kmer, const uint8_t kmerLength,
-		const uint8_t *restrict const sequence, const uint64_t sequenceLength);
+void checkRangeForCorrectness(const struct AwFmSearchRange *_RESTRICT_ const range,
+		const uint64_t *_RESTRICT_ const suffixArray, const char *kmer, const uint8_t kmerLength,
+		const uint8_t *_RESTRICT_ const sequence, const uint64_t sequenceLength);
 bool rangeCompare(struct AwFmSearchRange range1, struct AwFmSearchRange range2);
 void testAllKmerRanges(struct AwFmIndexConfiguration *config, uint64_t sequenceLength);
 
@@ -46,9 +46,9 @@ int main(int argc, char **argv) {
 }
 
 
-void checkRangeForCorrectness(const struct AwFmSearchRange *restrict const range,
-		const uint64_t *restrict const suffixArray, const char *kmer, const uint8_t kmerLength,
-		const uint8_t *restrict const sequence, const uint64_t sequenceLength) {
+void checkRangeForCorrectness(const struct AwFmSearchRange *_RESTRICT_ const range,
+		const uint64_t *_RESTRICT_ const suffixArray, const char *kmer, const uint8_t kmerLength,
+		const uint8_t *_RESTRICT_ const sequence, const uint64_t sequenceLength) {
 
 	// make a null terminated copy of the kmer
 	char kmerBuffer[kmerLength + 1];

--- a/test/multiSequenceIndexTest/AwFmMultiSequenceTest.c
+++ b/test/multiSequenceIndexTest/AwFmMultiSequenceTest.c
@@ -40,7 +40,7 @@ void testAwFmIndexGivesCorrectLocalPositions(void);
 void testAwFmIndexGivesCorrectHeaders(void);
 void compareIndicesForEqualityIgnoreVersion(const struct AwFmIndex *index1, const struct AwFmIndex *index2);
 void checkAllGlobalPositionsForCorrectLocalPositions(
-		const struct FastaVector *restrict const fastaVector, const struct AwFmIndex *restrict const fastaVectorIndex);
+		const struct FastaVector *_RESTRICT_ const fastaVector, const struct AwFmIndex *_RESTRICT_ const fastaVectorIndex);
 
 
 int main(int argc, char **argv) {
@@ -456,7 +456,7 @@ void compareIndicesForEqualityIgnoreVersion(const struct AwFmIndex *index1, cons
 }
 
 void checkAllGlobalPositionsForCorrectLocalPositions(
-		const struct FastaVector *restrict const fastaVector, const struct AwFmIndex *restrict const fastaVectorIndex) {
+		const struct FastaVector *_RESTRICT_ const fastaVector, const struct AwFmIndex *_RESTRICT_ const fastaVectorIndex) {
 
 	for(size_t sequenceIndex = 0; sequenceIndex < fastaVector->metadata.count; sequenceIndex++) {
 		size_t sequenceBeginPosition =

--- a/test/occupancyPerformanceTest/occSpeedTest.c
+++ b/test/occupancyPerformanceTest/occSpeedTest.c
@@ -54,7 +54,7 @@ void checkArgs() {
 	}
 }
 
-void performDbQueries(const struct AwFmIndex *restrict const index, uint64_t positionsInDb) {
+void performDbQueries(const struct AwFmIndex *_RESTRICT_ const index, uint64_t positionsInDb) {
 	size_t ptrs[2];
 	ptrs[0] = rand() % positionsInDb;
 	ptrs[1] = rand() % positionsInDb;

--- a/test/occurrenceTests/occurrenceTests.c
+++ b/test/occurrenceTests/occurrenceTests.c
@@ -27,13 +27,13 @@ int main(int argc, char **argv) {
 }
 
 
-void setVectorBytes(uint8_t *restrict const vector, const uint8_t byteValue) {
+void setVectorBytes(uint8_t *_RESTRICT_ const vector, const uint8_t byteValue) {
 	for(uint8_t i = 0; i < 32; i++) {
 		vector[i] = byteValue;
 	}
 }
 
-uint16_t setVectorRandBits(uint8_t *restrict const vector) {
+uint16_t setVectorRandBits(uint8_t *_RESTRICT_ const vector) {
 	uint8_t bitsSet = 0;
 	for(uint8_t byteIndex = 0; byteIndex < 32; byteIndex++) {
 		vector[byteIndex] = 0;

--- a/test/searchTest/searchTest.c
+++ b/test/searchTest/searchTest.c
@@ -37,7 +37,7 @@ bool sequencePositionInRange(
 void testRangeForCorrectness(const struct AwFmSearchRange *range, const uint8_t *sequence, const size_t sequenceLength,
 		const uint64_t *suffixArray, const char *kmer, const uint8_t kmerLength);
 struct AwFmSearchRange findRangeForKmer(
-		const struct AwFmIndex *restrict const index, const char *kmer, const uint64_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *kmer, const uint64_t kmerLength);
 
 
 #define GENERATE_INDEX_FROM_SCRATCH
@@ -180,6 +180,6 @@ void testRangeForCorrectness(const struct AwFmSearchRange *range, const uint8_t 
 
 
 struct AwFmSearchRange findRangeForKmer(
-		const struct AwFmIndex *restrict const index, const char *kmer, const uint64_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *kmer, const uint64_t kmerLength) {
 	return awFmDatabaseSingleKmerExactMatch(index, kmer, kmerLength);
 }


### PR DESCRIPTION
This PR updates the repo to use the cpp-compliant '__restrict__' keyword, instead of the c 'restrict' when compiled under c++. The build system still builds in C, but this should play nicer with linters and the such when used in a c++ codebase. Additionally, the cmake build system now correctly uses openmp. 