### PR TITLE
Add Rna alphabet

### DIFF
--- a/src/AwFmCreate.c
+++ b/src/AwFmCreate.c
@@ -257,7 +257,7 @@ enum AwFmReturnCode awFmCreateIndexFromFasta(struct AwFmIndex *_RESTRICT_ *index
 
 void setBwtAndPrefixSums(struct AwFmIndex *_RESTRICT_ const index, const size_t bwtLength,
 		const uint8_t *_RESTRICT_ const sequence, const uint64_t *_RESTRICT_ const unsampledSuffixArray) {
-	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+	if(index->config.alphabetType != AwFmAlphabetAmino) {
 		uint64_t baseOccurrences[8] = {0};
 		// baseOccurrences is length 8 because that's how long the signpost baseOccurrences in
 		// each window need to be to keep alignment to 32B AVX2 boundries.
@@ -375,7 +375,7 @@ void populateKmerSeedTableRecursive(struct AwFmIndex *_RESTRICT_ const index, st
 	// recursive case
 	for(uint8_t extendedLetter = 0; extendedLetter < alphabetSize; extendedLetter++) {
 		struct AwFmSearchRange newRange = range;
-		if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+		if(index->config.alphabetType != AwFmAlphabetAmino) {
 			awFmNucleotideIterativeStepBackwardSearch(index, &newRange, extendedLetter);
 		}
 		else {
@@ -392,7 +392,7 @@ void populateKmerSeedTableRecursive(struct AwFmIndex *_RESTRICT_ const index, st
 inline void fullSequenceSanitize(const uint8_t *const sequence, uint8_t *const sanitizedSequenceCopy,
 		const size_t sequenceLength, const enum AwFmAlphabetType alphabetType) {
 
-	if(alphabetType == AwFmAlphabetNucleotide) {
+	if(alphabetType != AwFmAlphabetAmino) {
 		for(size_t i = 0; i < sequenceLength; i++) {
 			sanitizedSequenceCopy[i] = awFmAsciiNucleotideLetterSanitize(sequence[i]);
 		}

--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -92,9 +92,9 @@ enum AwFmReturnCode awFmWriteIndexToFile(struct AwFmIndex *_RESTRICT_ const inde
 	}
 
 	const size_t numBlockInBwt		= awFmNumBlocksFromBwtLength(index->bwtLength);
-	const size_t bytesPerBwtBlock = index->config.alphabetType == AwFmAlphabetNucleotide ?
-																			sizeof(struct AwFmNucleotideBlock) :
-																			sizeof(struct AwFmAminoBlock);
+	const size_t bytesPerBwtBlock = index->config.alphabetType == AwFmAlphabetAmino ?
+																			sizeof(struct AwFmAminoBlock):
+																			sizeof(struct AwFmNucleotideBlock);
 
 	elementsWritten = fwrite(index->bwtBlockList.asNucleotide, bytesPerBwtBlock, numBlockInBwt, index->fileHandle);
 	if(elementsWritten != numBlockInBwt) {
@@ -270,9 +270,9 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 
 	// read the bwt block list
 	const size_t numBlockInBwt		= awFmNumBlocksFromBwtLength(indexData->bwtLength);
-	const size_t bytesPerBwtBlock = indexData->config.alphabetType == AwFmAlphabetNucleotide ?
-																			sizeof(struct AwFmNucleotideBlock) :
-																			sizeof(struct AwFmAminoBlock);
+	const size_t bytesPerBwtBlock = indexData->config.alphabetType == AwFmAlphabetAmino ?
+																			sizeof(struct AwFmAminoBlock):
+																			sizeof(struct AwFmNucleotideBlock);
 	elementsRead = fread(indexData->bwtBlockList.asNucleotide, bytesPerBwtBlock, numBlockInBwt, fileHandle);
 	if(elementsRead != numBlockInBwt) {
 		fclose(fileHandle);
@@ -452,9 +452,9 @@ enum AwFmReturnCode awFmGetSuffixArrayValueFromFile(
 
 size_t awFmGetSequenceFileOffset(const struct AwFmIndex *_RESTRICT_ const index) {
 	const size_t configLength						= 12 * sizeof(uint8_t);
-	const size_t bytesPerBwtBlock				= index->config.alphabetType == AwFmAlphabetNucleotide ?
-																						sizeof(struct AwFmNucleotideBlock) :
-																						sizeof(struct AwFmAminoBlock);
+	const size_t bytesPerBwtBlock				= index->config.alphabetType == AwFmAlphabetAmino ?
+																						sizeof(struct AwFmAminoBlock):
+																						sizeof(struct AwFmNucleotideBlock);
 	const size_t bwtLengthDataLength		= sizeof(uint64_t);
 	const size_t bwtLengthInBytes				= awFmNumBlocksFromBwtLength(index->bwtLength) * bytesPerBwtBlock;
 	const size_t prefixSumLengthInBytes = awFmGetPrefixSumsLength(index->config.alphabetType) * sizeof(uint64_t);

--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -30,7 +30,7 @@
 #define AW_FM_AMINO_CARDINALITY							20
 
 
-enum AwFmAlphabetType { AwFmAlphabetAmino = 1, AwFmAlphabetNucleotide = 2 };
+enum AwFmAlphabetType { AwFmAlphabetAmino = 1, AwFmAlphabetDna = 2, AwFmAlphabetRna = 3};
 
 // NOTE: not currently used, but this enum is kept for future use.
 enum AwFmBwtType { AwFmBwtTypeBackwardOnly = 1, AwFmBwtTypeBiDirectional = 2 };

--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -11,7 +11,7 @@
 
 
 #ifdef __cplusplus
-#define _RESTRICT_ __restrict_
+#define _RESTRICT_ __restrict__
 #else
 #define _RESTRICT_ restrict
 #endif

--- a/src/AwFmIndexStruct.c
+++ b/src/AwFmIndexStruct.c
@@ -30,8 +30,8 @@ struct AwFmIndex *awFmIndexAlloc(const struct AwFmIndexConfiguration *_RESTRICT_
 
 	// allocate the blockLists
 	size_t numBlocksInBwt = awFmNumBlocksFromBwtLength(bwtLength);
-	size_t sizeOfBwtBlock = config->alphabetType == AwFmAlphabetNucleotide ? sizeof(struct AwFmNucleotideBlock) :
-																																					 sizeof(struct AwFmAminoBlock);
+	size_t sizeOfBwtBlock = config->alphabetType == AwFmAlphabetAmino? 
+		sizeof(struct AwFmAminoBlock): sizeof(struct AwFmNucleotideBlock);
 
 	// alloc the backward bwt
 	index->bwtBlockList.asNucleotide = aligned_alloc(AW_FM_BWT_BYTE_ALIGNMENT, numBlocksInBwt * sizeOfBwtBlock);
@@ -69,7 +69,7 @@ void awFmDeallocIndex(struct AwFmIndex *index) {
 
 
 uint_fast8_t awFmGetAlphabetCardinality(const enum AwFmAlphabetType alphabet) {
-	return (alphabet == AwFmAlphabetNucleotide) ? AW_FM_NUCLEOTIDE_CARDINALITY : AW_FM_AMINO_CARDINALITY;
+	return (alphabet == AwFmAlphabetAmino) ? AW_FM_AMINO_CARDINALITY: AW_FM_NUCLEOTIDE_CARDINALITY;
 }
 
 

--- a/src/AwFmLetter.c
+++ b/src/AwFmLetter.c
@@ -12,7 +12,8 @@ uint8_t awFmAsciiNucleotideToLetterIndex(const uint8_t asciiLetter) {
 		case 'a': return 0;
 		case 'c': return 1;
 		case 'g': return 2;
-		case 't': return 3;
+		case 't': return 3;	//for DNA
+		case 'u': return 3;	//for RNA
 		case '$': return 5;
 		default: return 4;
 	}
@@ -25,7 +26,8 @@ uint8_t awFmAsciiNucleotideLetterSanitize(const uint8_t asciiLetter) {
 		case 'a': return 'a';
 		case 'c': return 'c';
 		case 'g': return 'g';
-		case 't': return 't';
+		case 't': return 't';	//for DNA
+		case 'u': return 'u';	//for RNA
 		case '$': return '$';	 // sentinel character
 		default: return 'x';	 // ambiguity character
 	}

--- a/src/AwFmLetter.h
+++ b/src/AwFmLetter.h
@@ -10,7 +10,7 @@
  * Function:  awFmAsciiNucleotideToLetterIndex
  * --------------------
  * Transforms an ascii nucleotide character into a bit-compressed index representation.
- * Any non-nucleotide (a,c,g,t,A,C,G, or T) character will be converted to index 4,
+ * Any non-nucleotide (a,c,g,t,u, A,C,G,T, or U) character will be converted to index 4,
  *  signifying a sentinel character.
  *
  *  This function should only be given nucleotides or sentinel '$' characters. Passing ambiguity codes

--- a/src/AwFmOccurrence.c
+++ b/src/AwFmOccurrence.c
@@ -24,7 +24,7 @@ AwFmSimdVec256 awFmMakeNucleotideOccurrenceVector(
 			return AwFmSimdVecAnd(bit2Vector, bit0Vector);
 		case 2:	 // Nucleotide G 0b011
 			return AwFmSimdVecAnd(bit1Vector, bit0Vector);
-		case 3:	 // Nucletoide T 0b001
+		case 3:	 // Nucletoide T (or U) 0b001
 			return AwFmSimdVecAndNot(bit2Vector, AwFmSimdVecAndNot(bit1Vector, bit0Vector));
 		case 4:	 // ambiguity character 'X' 0b010
 			return AwFmSimdVecAndNot(bit2Vector, AwFmSimdVecAndNot(bit0Vector, bit1Vector));

--- a/src/AwFmParallelSearch.c
+++ b/src/AwFmParallelSearch.c
@@ -189,7 +189,7 @@ void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *_RESTRICT_ cons
 		const char *kmerString											= searchData->kmerString;
 
 		const uint64_t rangesIndex = kmerIndex - threadBlockStartIndex;
-		if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+		if(index->config.alphabetType != AwFmAlphabetAmino) {
 			// TODO: reimplement partial seeded search when it's implementable
 			if(kmerLength < index->config.kmerLengthInSeedTable) {
 				awFmNucleotideNonSeededSearch(index, kmerString, kmerLength, &ranges[rangesIndex]);
@@ -230,7 +230,7 @@ void parallelSearchExtendKmersInBlock(const struct AwFmIndex *_RESTRICT_ const i
 				hasActiveQueries											= true;
 				const uint8_t currentQueryLetterIndex = kmerLength - currentKmerLetterIndex;
 
-				if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+				if(index->config.alphabetType != AwFmAlphabetAmino) {
 					const uint8_t queryLetterIndex = awFmAsciiNucleotideToLetterIndex(kmerString[currentQueryLetterIndex]);
 					awFmNucleotideIterativeStepBackwardSearch(index, &ranges[rangesIndex], queryLetterIndex);
 				}
@@ -264,7 +264,7 @@ enum AwFmReturnCode parallelSearchTracebackPositionLists(const struct AwFmIndex 
 			struct AwFmBacktrace backtrace = {
 					.position = ranges[rangesIndex].startPtr + indexOfPositionToBacktrace, .offset = 0};
 
-			if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+			if(index->config.alphabetType != AwFmAlphabetAmino) {
 				while(!awFmBwtPositionIsSampled(index, backtrace.position)) {
 					backtrace.position = awFmNucleotideBacktraceBwtPosition(index, backtrace.position);
 					backtrace.offset++;

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -9,7 +9,7 @@ struct AwFmSearchRange awFmCreateInitialQueryRange(
 		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const query, const uint8_t queryLength) {
 
 	uint8_t finalLetterIndexInQuery;
-	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+	if(index->config.alphabetType != AwFmAlphabetAmino) {
 		finalLetterIndexInQuery = awFmAsciiNucleotideToLetterIndex(query[queryLength - 1]);
 	}
 	else {
@@ -150,9 +150,8 @@ uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *_RESTRICT_ const 
 	}
 
 	// call a prefetch for each block that contains the positions that we need to start querying
-	const uint_fast16_t blockWidth = index->config.alphabetType == AwFmAlphabetNucleotide ?
-																			 sizeof(struct AwFmNucleotideBlock) :
-																			 sizeof(struct AwFmAminoBlock);
+	const uint_fast16_t blockWidth = index->config.alphabetType == AwFmAlphabetAmino ?
+		sizeof(struct AwFmAminoBlock): sizeof(struct AwFmNucleotideBlock);
 
 	for(uint64_t i = searchRange->startPtr; i < searchRange->endPtr; i += AW_FM_POSITIONS_PER_FM_BLOCK) {
 		awFmBlockPrefetch((uint8_t *)index->bwtBlockList.asAmino, blockWidth, i);
@@ -163,7 +162,7 @@ uint64_t *awFmFindDatabaseHitPositions(const struct AwFmIndex *_RESTRICT_ const 
 		uint64_t databaseSequenceOffset = 0;
 		uint64_t backtracePosition			= searchRange->startPtr + i;
 
-		if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+		if(index->config.alphabetType != AwFmAlphabetAmino) {
 			while(!awFmBwtPositionIsSampled(index, backtracePosition)) {
 				backtracePosition = awFmNucleotideBacktraceBwtPosition(index, backtracePosition);
 				databaseSequenceOffset++;
@@ -258,7 +257,7 @@ struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
 	uint16_t bwtBlockWidth;
 	uint8_t kmerLetterIndex;
 
-	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+	if(index->config.alphabetType != AwFmAlphabetAmino) {
 		bwtBlockWidth		= sizeof(struct AwFmNucleotideBlock);
 		kmerLetterIndex = awFmAsciiNucleotideToLetterIndex(kmer[kmerLetterPosition]);
 	}
@@ -273,7 +272,7 @@ struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
 
 	// start by prefetching the endptr
 	awFmBlockPrefetch(index->bwtBlockList.asNucleotide, bwtBlockWidth, range.endPtr);
-	if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+	if(index->config.alphabetType != AwFmAlphabetAmino) {
 		while(__builtin_expect(awFmSearchRangeIsValid(&range) && (kmerLetterPosition--), 1)) {
 			kmerLetterIndex = awFmAsciiNucleotideToLetterIndex(kmer[kmerLetterPosition]);
 			awFmNucleotideIterativeStepBackwardSearch(index, &range, kmerLetterIndex);

--- a/src/AwFmSearch.h
+++ b/src/AwFmSearch.h
@@ -43,7 +43,7 @@ struct AwFmSearchRange awFmDatabaseSingleKmerExactMatch(
  *
  *  Inputs:
  *    index: Index to backstep
- *    alphabet: alphabet of the index, either Nucleotide or Amino
+ *    alphabet: alphabet of the index, either Dna, Rna, or Amino
  *    bwtPosition: Position of the character to be returned.
  *
  *  Returns:
@@ -60,7 +60,7 @@ size_t awFmNucleotideBacktraceBwtPosition(const struct AwFmIndex *_RESTRICT_ con
  *
  *  Inputs:
  *    index: Index to backstep
- *    alphabet: alphabet of the index, either Nucleotide or Amino
+ *    alphabet: alphabet of the index, either Dna, Rna, or Amino
  *    bwtPosition: Position of the character to be returned.
  *
  *  Returns:

--- a/test/backtraceTest/backtraceTest.c
+++ b/test/backtraceTest/backtraceTest.c
@@ -68,10 +68,10 @@ void testNucleotideBacktrace() {
 
 
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = 1,
-				.kmerLengthInSeedTable																					 = 8,
-				.alphabetType																										 = AwFmAlphabetNucleotide,
-				.keepSuffixArrayInMemory																				 = false,
-				.storeOriginalSequence																					 = false};
+				.kmerLengthInSeedTable		= 8,
+				.alphabetType 				= AwFmAlphabetDna,
+				.keepSuffixArrayInMemory	= false,
+				.storeOriginalSequence		= false};
 		awFmCreateIndex(&index, &config, sequence, sequenceLength, "testIndex.awfmi");
 
 		if(index == NULL) {
@@ -140,11 +140,10 @@ void testAminoBacktrace(void) {
 		suffixArray[0] = sequenceLength;
 
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = 1,
-				.kmerLengthInSeedTable																					 = 4,
-				.alphabetType																										 = AwFmAlphabetAmino,
-				.keepSuffixArrayInMemory																				 = true,
-				.storeOriginalSequence																					 = true,
-				.storeOriginalSequence																					 = false};
+				.kmerLengthInSeedTable		= 4,
+				.alphabetType				= AwFmAlphabetAmino,
+				.keepSuffixArrayInMemory	= true,
+				.storeOriginalSequence		= false};
 		awFmCreateIndex(&index, &config, sequence, sequenceLength, "testIndex.awfmi");
 
 		if(index == NULL) {

--- a/test/backtraceTest/makefile
+++ b/test/backtraceTest/makefile
@@ -1,7 +1,14 @@
-TEST_SRC	= backtraceTest.c
-SRC 			= $(wildcard ../../src/*.c)
+TEST_SRC = backtraceTest.c
+SRC = $(wildcard ../../src/*.c)
 
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -O3 -L../../lib/libdivsufsort/build/lib
-EXE 		= backtraceTest.out
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = backtraceTest.out
+
 backtraceTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/bwtTest/bwtTest.c
+++ b/test/bwtTest/bwtTest.c
@@ -89,10 +89,10 @@ void testNucletotideBwtGeneration(void) {
 
 		struct AwFmIndex *index;
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = 240,
-				.kmerLengthInSeedTable																					 = 2,
-				.alphabetType																										 = AwFmAlphabetNucleotide,
-				.keepSuffixArrayInMemory																				 = false,
-				.storeOriginalSequence																					 = true};
+				.kmerLengthInSeedTable		= 2,
+				.alphabetType				= AwFmAlphabetDna,
+				.keepSuffixArrayInMemory	= false,
+				.storeOriginalSequence		= true};
 		awFmCreateIndex(&index, &config, sequence, sequenceLength, "testIndex.awfmi");
 
 		for(size_t i = 0; i <= sequenceLength; i++) {

--- a/test/bwtTest/makefile
+++ b/test/bwtTest/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= bwtTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -Wall -fsanitize=address -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= bwtTest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = bwtTest.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = bwtTest.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/createTests/AwFmCreationTest.c
+++ b/test/createTests/AwFmCreationTest.c
@@ -100,12 +100,12 @@ struct AwFmIndex *testCreateNucleotideIndex(const uint8_t *sequence, const size_
 
 	const bool keepSuffixArrayInMemory = false;
 	// not using initilize because valgrind complains about the padding bytes when I do it.
-	struct AwFmIndexConfiguration config = {0};
-	config.suffixArrayCompressionRatio	 = 1;
-	config.kmerLengthInSeedTable				 = 4;
-	config.alphabetType									 = AwFmAlphabetNucleotide;
-	config.keepSuffixArrayInMemory			 = false;
-	config.storeOriginalSequence				 = false;
+	struct AwFmIndexConfiguration config 	= {0};
+	config.suffixArrayCompressionRatio	 	= 1;
+	config.kmerLengthInSeedTable			= 4;
+	config.alphabetType						= AwFmAlphabetDna;
+	config.keepSuffixArrayInMemory			= false;
+	config.storeOriginalSequence			= false;
 
 	const uint32_t expectedVersionNumber = AW_FM_CURRENT_VERSION_NUMBER;
 	struct AwFmIndex *_RESTRICT_ index;
@@ -152,9 +152,9 @@ void testPrefixSums(
 	printf("\n");
 
 	for(size_t seqPos = 0; seqPos < sequenceLength; seqPos++) {
-		uint8_t letterAsIndex = index->config.alphabetType == AwFmAlphabetNucleotide ?
-																awFmAsciiNucleotideToLetterIndex(sequence[seqPos]) :
-																awFmAsciiAminoAcidToLetterIndex(sequence[seqPos]);
+		uint8_t letterAsIndex = index->config.alphabetType == AwFmAlphabetAmino ?
+																awFmAsciiAminoAcidToLetterIndex(sequence[seqPos]):
+																awFmAsciiNucleotideToLetterIndex(sequence[seqPos]);
 		letterCounts[letterAsIndex]++;
 	}
 
@@ -198,9 +198,9 @@ void testKmerTableLengths(
 
 		// printf("for kmer %.*s, found %zu.\n", kmerLength, kmerPtr1, kmerCount);
 		const struct AwFmSearchRange rangeInTable =
-				index->config.alphabetType == AwFmAlphabetNucleotide ?
-						awFmNucleotideKmerSeedRangeFromTable(index, (char *)kmerPtr1, kmerLength) :
-						awFmAminoKmerSeedRangeFromTable(index, (char *)kmerPtr1, kmerLength);
+				index->config.alphabetType == AwFmAlphabetAmino ?
+						awFmAminoKmerSeedRangeFromTable(index, (char *)kmerPtr1, kmerLength):
+						awFmNucleotideKmerSeedRangeFromTable(index, (char *)kmerPtr1, kmerLength);
 
 		const size_t numInRange = rangeInTable.endPtr - rangeInTable.startPtr + 1;
 

--- a/test/createTests/makefile
+++ b/test/createTests/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= AwFmCreationTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= createTest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = AwFmCreationTest.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = createTest.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/fileTests/AwFmFileTests.c
+++ b/test/fileTests/AwFmFileTests.c
@@ -49,10 +49,10 @@ void sequenceRecallTest(void) {
 
 		struct AwFmIndex *index;
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = 240,
-				.kmerLengthInSeedTable																					 = 2,
-				.alphabetType																										 = AwFmAlphabetNucleotide,
-				.keepSuffixArrayInMemory																				 = false,
-				.storeOriginalSequence																					 = true};
+				.kmerLengthInSeedTable		= 2,
+				.alphabetType			 	= AwFmAlphabetDna,
+				.keepSuffixArrayInMemory	= false,
+				.storeOriginalSequence		= true};
 		awFmCreateIndex(&index, &config, sequence, sequenceLength, "testIndex.awfmi");
 
 		char sequenceBuffer[2048];
@@ -125,10 +125,10 @@ void suffixArrayTest(void) {
 		printf("    compression ratio %zu, nucleotide\n", compressionRatio);
 		struct AwFmIndex *index;
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = compressionRatio,
-				.kmerLengthInSeedTable																					 = 2,
-				.alphabetType																										 = AwFmAlphabetNucleotide,
-				.keepSuffixArrayInMemory																				 = false,
-				.storeOriginalSequence																					 = true};
+				.kmerLengthInSeedTable		= 2,
+				.alphabetType				= AwFmAlphabetDna,
+				.keepSuffixArrayInMemory	= false,
+				.storeOriginalSequence		= true};
 
 		const size_t sequenceLength = 4000 + rand() % 2000;
 		uint8_t *sequence						= malloc((sequenceLength + 1) * sizeof(uint8_t));
@@ -207,7 +207,7 @@ void indexReadTest(void) {
 	for(size_t testNum = 0; testNum < 100; testNum++) {
 		printf("test %zu\n", testNum);
 		const uint8_t kmerLengthInSeedTable			 = rand() % 3 + 2;
-		const enum AwFmAlphabetType alphabetType = rand() & 1 ? AwFmAlphabetNucleotide : AwFmAlphabetAmino;
+		const enum AwFmAlphabetType alphabetType = rand() & 1 ? AwFmAlphabetDna : AwFmAlphabetAmino;
 
 		const uint64_t sequenceLength = 10000 + (rand() % 1000);
 		uint8_t *sequence							= malloc(sequenceLength * sizeof(uint8_t));
@@ -218,7 +218,7 @@ void indexReadTest(void) {
 
 		// randomize the sequence
 		for(size_t i = 0; i < sequenceLength; i++) {
-			sequence[i] = alphabetType == AwFmAlphabetNucleotide ? nucleotideLookup[rand() % 5] : aminoLookup[rand() % 21];
+			sequence[i] = alphabetType == AwFmAlphabetDna ? nucleotideLookup[rand() % 5] : aminoLookup[rand() % 21];
 		}
 
 		struct AwFmIndex *index;
@@ -283,9 +283,9 @@ void indexReadTest(void) {
 
 		// bwtBlockList
 		size_t blockListLengthInBytes =
-				alphabetType == AwFmAlphabetNucleotide ?
-						awFmNumBlocksFromBwtLength(index->bwtLength) * sizeof(struct AwFmNucleotideBlock) :
-						awFmNumBlocksFromBwtLength(index->bwtLength) * sizeof(struct AwFmAminoBlock);
+				alphabetType == AwFmAlphabetAmino ?
+						awFmNumBlocksFromBwtLength(index->bwtLength) * sizeof(struct AwFmAminoBlock):
+						awFmNumBlocksFromBwtLength(index->bwtLength) * sizeof(struct AwFmNucleotideBlock);
 
 		sprintf(buffer, "the bwt block lists of the original and the one from file did not match.");
 		testAssertString(

--- a/test/fileTests/makefile
+++ b/test/fileTests/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= AwFmFileTests.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= fileTests.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = AwFmFileTests.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = fileTests.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/inMemorySaTest/inMemorySaTest.c
+++ b/test/inMemorySaTest/inMemorySaTest.c
@@ -47,10 +47,10 @@ void inMemorySaUncompressedTest(void) {
 
 		struct AwFmIndex *index;
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = 1,
-				.kmerLengthInSeedTable																					 = 8,
-				.alphabetType																										 = AwFmAlphabetNucleotide,
-				.keepSuffixArrayInMemory																				 = true,
-				.storeOriginalSequence																					 = true};
+				.kmerLengthInSeedTable		= 8,
+				.alphabetType				= AwFmAlphabetDna,
+				.keepSuffixArrayInMemory	= true,
+				.storeOriginalSequence		= true};
 
 
 		enum AwFmReturnCode returnCode =
@@ -117,10 +117,10 @@ void inMemorySaCompressedTest(void) {
 		struct AwFmIndex *index;
 		// as an extreme edge case, compress the SA to only one value.
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = sequenceLength - 1,
-				.kmerLengthInSeedTable																					 = 8,
-				.alphabetType																										 = AwFmAlphabetNucleotide,
-				.keepSuffixArrayInMemory																				 = true,
-				.storeOriginalSequence																					 = true};
+				.kmerLengthInSeedTable		= 8,
+				.alphabetType				= AwFmAlphabetDna,
+				.keepSuffixArrayInMemory	= true,
+				.storeOriginalSequence		= true};
 
 
 		awFmCreateIndex(&index, &config, sequence, sequenceLength, "testIndex.awfmi");
@@ -184,10 +184,10 @@ void inMemoryFromFileTest(void) {
 
 		struct AwFmIndex *index;
 		struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = 16,
-				.kmerLengthInSeedTable																					 = 8,
-				.alphabetType																										 = AwFmAlphabetNucleotide,
-				.keepSuffixArrayInMemory																				 = true,
-				.storeOriginalSequence																					 = true};
+				.kmerLengthInSeedTable		= 8,
+				.alphabetType				= AwFmAlphabetDna,
+				.keepSuffixArrayInMemory	= true,
+				.storeOriginalSequence		= true};
 
 
 		awFmCreateIndex(&index, &config, sequence, sequenceLength, "testIndex.awfmi");

--- a/test/inMemorySaTest/makefile
+++ b/test/inMemorySaTest/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= inMemorySaTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= saInMemTest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = inMemorySaTest.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = saInMemTest.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/kmerSeedTableTests/kmerSeedTableTests.c
+++ b/test/kmerSeedTableTests/kmerSeedTableTests.c
@@ -32,9 +32,9 @@ int main(int argc, char **argv) {
 	printf("main\n");
 
 	struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = 240,
-			.kmerLengthInSeedTable																					 = 5,
-			.alphabetType																										 = AwFmAlphabetNucleotide,
-			.keepSuffixArrayInMemory																				 = false};
+			.kmerLengthInSeedTable		= 5,
+			.alphabetType				= AwFmAlphabetDna,
+			.keepSuffixArrayInMemory	= false};
 	testAllKmerRanges(&config, 2000);
 
 	printf("testing amino ranges\n");
@@ -117,8 +117,8 @@ void testAllKmerRanges(struct AwFmIndexConfiguration *config, uint64_t sequenceL
 			exit(-1);
 		}
 		for(uint64_t i = 0; i < sequenceLength; i++) {
-			sequence[i] =
-					(config->alphabetType == AwFmAlphabetNucleotide ? nucleotideLookup[rand() % 5] : aminoLookup[rand() % 21]);
+			sequence[i] = (config->alphabetType == AwFmAlphabetAmino) ? 
+				aminoLookup[rand() % 21]:	nucleotideLookup[rand() % 5]; 
 		}
 		// null terminate the sequence
 		sequence[sequenceLength] = 0;
@@ -159,7 +159,7 @@ void testAllKmerRanges(struct AwFmIndexConfiguration *config, uint64_t sequenceL
 
 		struct AwFmSearchRange range = {0, 0};
 		char *kmer2									 = "agaaa";
-		if(config->alphabetType == AwFmAlphabetNucleotide) {
+		if(config->alphabetType != AwFmAlphabetAmino) {
 			awFmNucleotideNonSeededSearch(index, kmer2, 5, &range);
 		}
 		else {
@@ -192,7 +192,7 @@ void testAllKmerRanges(struct AwFmIndexConfiguration *config, uint64_t sequenceL
 			}
 			size_t kmerIndexCopy = kmerIndex;
 			for(uint8_t letterInKmer = 0; letterInKmer < kmerLength; letterInKmer++) {
-				if(index->config.alphabetType == AwFmAlphabetNucleotide) {
+				if(index->config.alphabetType != AwFmAlphabetAmino) {
 					kmer[letterInKmer] = nucleotideLookup[(kmerIndexCopy % 4)];
 					kmerIndexCopy /= 4;
 				}
@@ -201,9 +201,9 @@ void testAllKmerRanges(struct AwFmIndexConfiguration *config, uint64_t sequenceL
 					kmerIndexCopy /= 20;
 				}
 			}
-			struct AwFmSearchRange kmerRange = config->alphabetType == AwFmAlphabetNucleotide ?
-																						 awFmNucleotideKmerSeedRangeFromTable(index, kmer, kmerLength) :
-																						 awFmAminoKmerSeedRangeFromTable(index, kmer, kmerLength);
+			struct AwFmSearchRange kmerRange = config->alphabetType == AwFmAlphabetAmino ?
+				awFmAminoKmerSeedRangeFromTable(index, kmer, kmerLength):
+				awFmNucleotideKmerSeedRangeFromTable(index, kmer, kmerLength);
 
 			checkRangeForCorrectness(&kmerRange, suffixArray, kmer, kmerLength, sequence, sequenceLength);
 		}

--- a/test/kmerSeedTableTests/makefile
+++ b/test/kmerSeedTableTests/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= kmerSeedTableTests.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -Wall -fsanitize=address -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= kmerTableTests.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = kmerSeedTableTests.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = kmerSeedTableTests.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/letterTest/AwFmLetterTest.c
+++ b/test/letterTest/AwFmLetterTest.c
@@ -30,7 +30,7 @@ void testNucleotideAscii() {
 				testAssert(awFmAsciiNucleotideToLetterIndex(awFmAsciiNucleotideLetterSanitize(c)) == 2);
 				testAssert(awFmAsciiNucleotideToLetterIndex(awFmAsciiNucleotideLetterSanitize(toupper(c))) == 2);
 				break;
-			case 't':
+			case 't': case 'u':
 				testAssert(awFmAsciiNucleotideToLetterIndex(awFmAsciiNucleotideLetterSanitize(c)) == 3);
 				testAssert(awFmAsciiNucleotideToLetterIndex(awFmAsciiNucleotideLetterSanitize(toupper(c))) == 3);
 				break;

--- a/test/letterTest/makefile
+++ b/test/letterTest/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= AwFmLetterTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= lettertest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = AwFmLetterTest.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = letterTest.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/multiSequenceIndexTest/AwFmMultiSequenceTest.c
+++ b/test/multiSequenceIndexTest/AwFmMultiSequenceTest.c
@@ -98,8 +98,8 @@ void getRawSequenceFromFastaVector(
 struct AwFmIndexConfiguration generateReasonableRandomMetadata() {
 	struct AwFmIndexConfiguration config;
 	config.suffixArrayCompressionRatio = (rand() % 20) + 1;
-	config.alphabetType								 = (rand() % 2) == 0 ? AwFmAlphabetAmino : AwFmAlphabetNucleotide;
-	config.kmerLengthInSeedTable	 = config.alphabetType == AwFmAlphabetNucleotide ? (rand() % 10) + 2 : (rand() % 4) + 1;
+	config.alphabetType								 = (rand() % 2) == 0 ? AwFmAlphabetAmino : AwFmAlphabetDna;
+	config.kmerLengthInSeedTable	 = config.alphabetType == AwFmAlphabetDna ? (rand() % 10) + 2 : (rand() % 4) + 1;
 	config.keepSuffixArrayInMemory = true;
 	config.storeOriginalSequence = true;
 
@@ -392,7 +392,7 @@ void compareIndicesForEqualityIgnoreVersion(const struct AwFmIndex *index1, cons
 	// compare bwts
 	const size_t numBwtBlocks = index1->bwtLength / 256;
 	for(size_t blockIndex = 0; blockIndex < numBwtBlocks; blockIndex++) {
-		if(index1->config.alphabetType == AwFmAlphabetNucleotide) {
+		if(index1->config.alphabetType == AwFmAlphabetDna) {
 			bool blocksAreEqual =
 					memcmp(&index1->bwtBlockList.asNucleotide[blockIndex], &index2->bwtBlockList.asNucleotide[blockIndex],
 							sizeof(struct AwFmNucleotideBlock)) == 0;
@@ -424,7 +424,7 @@ void compareIndicesForEqualityIgnoreVersion(const struct AwFmIndex *index1, cons
 	}
 
 	// compare prefix sums
-	const size_t numPrefixSums = index1->config.alphabetType == AwFmAlphabetNucleotide ? 6 : 22;
+	const size_t numPrefixSums = index1->config.alphabetType == AwFmAlphabetDna ? 6 : 22;
 	for(size_t prefixSumIndex = 0; prefixSumIndex < numPrefixSums; prefixSumIndex++) {
 		sprintf(buffer, "index 1 prefix sum #%zu (%zu) did not compare equal to matching index 2 prefix sum (%zu).",
 				prefixSumIndex, index1->prefixSums[prefixSumIndex], index2->prefixSums[prefixSumIndex]);

--- a/test/multiSequenceIndexTest/AwFmMultiSequenceTest.c
+++ b/test/multiSequenceIndexTest/AwFmMultiSequenceTest.c
@@ -101,6 +101,7 @@ struct AwFmIndexConfiguration generateReasonableRandomMetadata() {
 	config.alphabetType								 = (rand() % 2) == 0 ? AwFmAlphabetAmino : AwFmAlphabetNucleotide;
 	config.kmerLengthInSeedTable	 = config.alphabetType == AwFmAlphabetNucleotide ? (rand() % 10) + 2 : (rand() % 4) + 1;
 	config.keepSuffixArrayInMemory = true;
+	config.storeOriginalSequence = true;
 
 	return config;
 }

--- a/test/multiSequenceIndexTest/makefile
+++ b/test/multiSequenceIndexTest/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= AwFmMultiSequenceTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -lfastavector -ldivsufsort64 -fopenmp -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= multiSequenceTest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = AwFmMultiSequenceTest.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O0 -g
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = multiSequenceTest.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/occupancyPerformanceTest/makefile
+++ b/test/occupancyPerformanceTest/makefile
@@ -1,6 +1,7 @@
-TEST_SRC	= occSpeedTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -Wall -mtune=native -g -fopenmp -ldivsufsort64 -mavx2 -I../../libdivsufsort/build/include
-EXE 		= occSpeedTest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+# this test is deprecated
+# TEST_SRC	= occSpeedTest.c
+# SRC 			= $(wildcard ../../src/*.c)
+# CFLAGS 	= -std=c11 -Wall -mtune=native -g -fopenmp -ldivsufsort64 -mavx2 -I../../libdivsufsort/build/include
+# EXE 		= occSpeedTest.out
+# bwtTest: $(SRC)
+# 	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)

--- a/test/occupancyPerformanceTest/occSpeedTest.c
+++ b/test/occupancyPerformanceTest/occSpeedTest.c
@@ -1,124 +1,125 @@
-#include <getopt.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+//this test is deprecated
+// #include <getopt.h>
+// #include <stdbool.h>
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <time.h>
 
-#include "../../src/AwFmIndex.h"
-#include "../../src/AwFmIndexStruct.h"
-#include "../../src/AwFmOccurrence.h"
-
-
-uint32_t numQueries							 = 0;
-uint32_t dbSizeInWindows				 = 0;
-bool requestOccupancyPrefetching = false;
+// #include "../../src/AwFmIndex.h"
+// #include "../../src/AwFmIndexStruct.h"
+// #include "../../src/AwFmOccurrence.h"
 
 
-void parseArgs(int argc, char **argv) {
-	int option = 0;
-	while((option = getopt(argc, argv, "pq:s:")) != -1) {
-		printf("option: %c ", option);
-		switch(option) {
-			case 'p':
-				printf("prefetching requested\n");
-				requestOccupancyPrefetching = true;
-				break;
-			case 'q':
-				numQueries = atoi(optarg);
-				printf("num queries: %d\n", numQueries);
-				break;
-			case 's':
-				dbSizeInWindows = atoi(optarg);
-				printf("db size in windows: %d\n", dbSizeInWindows);
-				break;
-			case '?': printf("unknown option flag given: %c is not a supported flag.\n", optopt); break;
-		}
-	}
-}
-
-void checkArgs() {
-	bool allArgumentsParsed = true;
-	if(numQueries == 0) {
-		printf(
-				"Num queries was not given (or was given 0). please provide the number of queries to perform with the -q "
-				"flag\n");
-		allArgumentsParsed = false;
-	}
-	if(dbSizeInWindows == 0) {
-		printf(
-				"database size was not given (or was given 0). please provide the size of the db to test with the -s flag\n");
-		allArgumentsParsed = false;
-	}
-	if(!allArgumentsParsed) {
-		exit(-1);
-	}
-}
-
-void performDbQueries(const struct AwFmIndex *_RESTRICT_ const index, uint64_t positionsInDb) {
-	size_t ptrs[2];
-	ptrs[0] = rand() % positionsInDb;
-	ptrs[1] = rand() % positionsInDb;
+// uint32_t numQueries							 = 0;
+// uint32_t dbSizeInWindows				 = 0;
+// bool requestOccupancyPrefetching = false;
 
 
-	if(requestOccupancyPrefetching) {
-		for(uint32_t i = 0; i < numQueries; i++) {
-			uint8_t letter = rand() % 20;
-			ptrs[0]				 = awFmGetOccupancy(index, ptrs[0], letter) + index->rankPrefixSums[letter];
-			ptrs[0]				 = ptrs[0] % positionsInDb;
-			awFmOccupancyDataPrefetch(index, ptrs[0]);
+// void parseArgs(int argc, char **argv) {
+// 	int option = 0;
+// 	while((option = getopt(argc, argv, "pq:s:")) != -1) {
+// 		printf("option: %c ", option);
+// 		switch(option) {
+// 			case 'p':
+// 				printf("prefetching requested\n");
+// 				requestOccupancyPrefetching = true;
+// 				break;
+// 			case 'q':
+// 				numQueries = atoi(optarg);
+// 				printf("num queries: %d\n", numQueries);
+// 				break;
+// 			case 's':
+// 				dbSizeInWindows = atoi(optarg);
+// 				printf("db size in windows: %d\n", dbSizeInWindows);
+// 				break;
+// 			case '?': printf("unknown option flag given: %c is not a supported flag.\n", optopt); break;
+// 		}
+// 	}
+// }
 
-			ptrs[1] = awFmGetOccupancy(index, ptrs[1], letter) + index->rankPrefixSums[letter];
-			ptrs[1] = ptrs[1] % positionsInDb;
-			awFmOccupancyDataPrefetch(index, ptrs[1]);
-		}
-	}
-	else {
-		for(uint32_t i = 0; i < numQueries; i++) {
-			uint8_t letter = rand() % 20;
-			ptrs[0]				 = awFmGetOccupancy(index, ptrs[0], letter) + index->rankPrefixSums[letter];
-			ptrs[0]				 = ptrs[0] % positionsInDb;
+// void checkArgs() {
+// 	bool allArgumentsParsed = true;
+// 	if(numQueries == 0) {
+// 		printf(
+// 				"Num queries was not given (or was given 0). please provide the number of queries to perform with the -q "
+// 				"flag\n");
+// 		allArgumentsParsed = false;
+// 	}
+// 	if(dbSizeInWindows == 0) {
+// 		printf(
+// 				"database size was not given (or was given 0). please provide the size of the db to test with the -s flag\n");
+// 		allArgumentsParsed = false;
+// 	}
+// 	if(!allArgumentsParsed) {
+// 		exit(-1);
+// 	}
+// }
 
-			ptrs[1] = awFmGetOccupancy(index, ptrs[1], letter) + index->rankPrefixSums[letter];
-			ptrs[1] = ptrs[1] % positionsInDb;
-		}
-	}
-}
+// void performDbQueries(const struct AwFmIndex *_RESTRICT_ const index, uint64_t positionsInDb) {
+// 	size_t ptrs[2];
+// 	ptrs[0] = rand() % positionsInDb;
+// 	ptrs[1] = rand() % positionsInDb;
 
-int main(int argc, char **argv) {
-	srand(time(NULL));
-	parseArgs(argc, argv);
-	checkArgs();
-	uint64_t positionsInDb = dbSizeInWindows * POSITIONS_PER_FM_BLOCK;
-	// create the "database"
-	struct AwFmBlock *blockList = awFmAlignedAllocBlockList(dbSizeInWindows);
-	if(blockList == NULL) {
-		printf("could not allocate block list... maybe window count of %d was too big?\n", dbSizeInWindows);
-		exit(-2);
-	}
 
-	// randomize the data in the blocklist
-	for(size_t i = 0; i < (sizeof(struct AwFmBlock) * dbSizeInWindows) / sizeof(uint32_t); i++) {
-		((uint32_t *)blockList)[i] = rand();
-	}
+// 	if(requestOccupancyPrefetching) {
+// 		for(uint32_t i = 0; i < numQueries; i++) {
+// 			uint8_t letter = rand() % 20;
+// 			ptrs[0]				 = awFmGetOccupancy(index, ptrs[0], letter) + index->rankPrefixSums[letter];
+// 			ptrs[0]				 = ptrs[0] % positionsInDb;
+// 			awFmOccupancyDataPrefetch(index, ptrs[0]);
 
-	struct AwFmIndex *index = awFmAlignedAllocAwFmIndex();
-	if(index == NULL) {
-		printf("could not allocate index... wtf?\n");
-		exit(-2);
-	}
-	// set the block list in or fake index.
-	index->blockList = blockList;
-	for(size_t i = 0; i <= AMINO_CARDINALITY; i++) {
-		size_t prefixSum														 = (positionsInDb / AMINO_CARDINALITY) * i;
-		index->rankPrefixSums[AMINO_CARDINALITY - i] = prefixSum;
-	}
+// 			ptrs[1] = awFmGetOccupancy(index, ptrs[1], letter) + index->rankPrefixSums[letter];
+// 			ptrs[1] = ptrs[1] % positionsInDb;
+// 			awFmOccupancyDataPrefetch(index, ptrs[1]);
+// 		}
+// 	}
+// 	else {
+// 		for(uint32_t i = 0; i < numQueries; i++) {
+// 			uint8_t letter = rand() % 20;
+// 			ptrs[0]				 = awFmGetOccupancy(index, ptrs[0], letter) + index->rankPrefixSums[letter];
+// 			ptrs[0]				 = ptrs[0] % positionsInDb;
 
-	clock_t before = clock();
-	performDbQueries(index, positionsInDb);
-	clock_t timeElapsed = clock() - before;
+// 			ptrs[1] = awFmGetOccupancy(index, ptrs[1], letter) + index->rankPrefixSums[letter];
+// 			ptrs[1] = ptrs[1] % positionsInDb;
+// 		}
+// 	}
+// }
 
-	double seconds = (double)timeElapsed / CLOCKS_PER_SEC;
-	printf("completed test in %f seconds. queries: %d, numWindows: %d\n\n\n", seconds, numQueries, dbSizeInWindows);
-	free(index->blockList);
-	free(index);
-}
+// int main(int argc, char **argv) {
+// 	srand(time(NULL));
+// 	parseArgs(argc, argv);
+// 	checkArgs();
+// 	uint64_t positionsInDb = dbSizeInWindows * POSITIONS_PER_FM_BLOCK;
+// 	// create the "database"
+// 	struct AwFmBlock *blockList = awFmAlignedAllocBlockList(dbSizeInWindows);
+// 	if(blockList == NULL) {
+// 		printf("could not allocate block list... maybe window count of %d was too big?\n", dbSizeInWindows);
+// 		exit(-2);
+// 	}
+
+// 	// randomize the data in the blocklist
+// 	for(size_t i = 0; i < (sizeof(struct AwFmBlock) * dbSizeInWindows) / sizeof(uint32_t); i++) {
+// 		((uint32_t *)blockList)[i] = rand();
+// 	}
+
+// 	struct AwFmIndex *index = awFmAlignedAllocAwFmIndex();
+// 	if(index == NULL) {
+// 		printf("could not allocate index... wtf?\n");
+// 		exit(-2);
+// 	}
+// 	// set the block list in or fake index.
+// 	index->blockList = blockList;
+// 	for(size_t i = 0; i <= AMINO_CARDINALITY; i++) {
+// 		size_t prefixSum														 = (positionsInDb / AMINO_CARDINALITY) * i;
+// 		index->rankPrefixSums[AMINO_CARDINALITY - i] = prefixSum;
+// 	}
+
+// 	clock_t before = clock();
+// 	performDbQueries(index, positionsInDb);
+// 	clock_t timeElapsed = clock() - before;
+
+// 	double seconds = (double)timeElapsed / CLOCKS_PER_SEC;
+// 	printf("completed test in %f seconds. queries: %d, numWindows: %d\n\n\n", seconds, numQueries, dbSizeInWindows);
+// 	free(index->blockList);
+// 	free(index);
+// }

--- a/test/occurrenceTests/makefile
+++ b/test/occurrenceTests/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= occurrenceTests.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= occurrenceTests.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = occurrenceTests.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O0 -g
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = occurrenceTests.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/occurrenceTests/occurrenceTests.c
+++ b/test/occurrenceTests/occurrenceTests.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-#include "../../libdivsufsort/build/include/divsufsort64.h"
+#include "../../lib/libdivsufsort/build/include/divsufsort64.h"
 #include "../../src/AwFmCreate.h"
 #include "../../src/AwFmIndex.h"
 #include "../../src/AwFmIndexStruct.h"

--- a/test/parallelSearch/makefile
+++ b/test/parallelSearch/makefile
@@ -1,6 +1,14 @@
-TEST_SRC	= parallelSearchTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-EXE 		= parallelSearchTest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = parallelSearchTest.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O0 -g
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = parallelSearchTest.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/parallelSearch/parallelSearchTest.c
+++ b/test/parallelSearch/parallelSearchTest.c
@@ -197,10 +197,10 @@ void testParallelSearchAmino(void) {
 void testParallelSearchNucleotide() {
 	struct AwFmIndex *index;
 	struct AwFmIndexConfiguration config = {.suffixArrayCompressionRatio = saCompressionRatio,
-			.kmerLengthInSeedTable																					 = 9,
-			.alphabetType																										 = AwFmAlphabetNucleotide,
-			.keepSuffixArrayInMemory																				 = true,
-			.storeOriginalSequence																					 = false};
+			.kmerLengthInSeedTable		= 9,
+			.alphabetType				= AwFmAlphabetDna,
+			.keepSuffixArrayInMemory	= true,
+			.storeOriginalSequence		= false};
 
 	const uint64_t sequenceLength = 5000 + rand() % 5000;
 	printf("creating nucleotide sequence of length %zu.\n", sequenceLength);

--- a/test/popcountTest/makefile
+++ b/test/popcountTest/makefile
@@ -1,6 +1,15 @@
-TEST_SRC	= popcountTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -I../../libdivsufsort/build/include
-EXE 		= popcountTest.out
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+# this test is deprecated
+# TEST_SRC = popcountTest.c
+# SRC = $(wildcard ../../src/*.c)
+
+# CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O0 -g
+# LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+# EXE = popcountTest.out
+
+# backtraceTest: $(SRC)
+# 	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+# .PHONY: clean
+# clean:
+# 	rm -f $(EXE)

--- a/test/popcountTest/popcountTest.c
+++ b/test/popcountTest/popcountTest.c
@@ -1,199 +1,200 @@
-#include <getopt.h>
-#include <immintrin.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+//this test is deprecated.
+// #include <getopt.h>
+// #include <immintrin.h>
+// #include <stdbool.h>
+// #include <stdint.h>
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <string.h>
+// #include <time.h>
 
-#include "../../src/AwFmIndexStruct.h"
-
-
-// without cache stuff (using same vector), awFmVectorPopcountShift is ~8% faster than mula
-size_t length;
-volatile size_t offset = 0;
-
-uint8_t extractPopcnt(volatile __m256i vec) {
-	return _mm_popcnt_u64(_mm256_extract_epi64(vec, 0)) + _mm_popcnt_u64(_mm256_extract_epi64(vec, 1)) +
-				 _mm_popcnt_u64(_mm256_extract_epi64(vec, 2)) + _mm_popcnt_u64(_mm256_extract_epi64(vec, 3));
-}
-
-uint8_t storePopcnt(volatile __m256i vec) {
-	uint8_t unalignedBuffer[32 + 31];
-	uint8_t *alignedBuffer = (uint8_t *)((intptr_t)(unalignedBuffer + 31) & ~31);
-	_mm256_store_si256((__m256i *)alignedBuffer, vec);
-
-	uint64_t *bufferAs64_t = (uint64_t *)alignedBuffer;
-	return _mm_popcnt_u64(bufferAs64_t[0]) + _mm_popcnt_u64(bufferAs64_t[1]) + _mm_popcnt_u64(bufferAs64_t[2]) +
-				 _mm_popcnt_u64(bufferAs64_t[3]);
-}
+// #include "../../src/AwFmIndexStruct.h"
 
 
-inline uint_fast8_t awFmVectorPopcountShift(const __m256i occurrenceVector) {
-	const __m256i lowBitsLookupTable =
-			_mm256_setr_epi8(4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0, 4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0);
-	const __m256i highBitsLookupTable = _mm256_setr_epi8(-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0,
-			-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0);
+// // without cache stuff (using same vector), awFmVectorPopcountShift is ~8% faster than mula
+// size_t length;
+// volatile size_t offset = 0;
 
-	const __m256i lowNybbleBitmasked				 = _mm256_and_si256(occurrenceVector, _mm256_set1_epi8(0x0F));
-	const __m256i lowNybbleBitCount					 = _mm256_shuffle_epi8(lowBitsLookupTable, lowNybbleBitmasked);
-	const __m256i highNybbleBits						 = _mm256_srli_si256(occurrenceVector, 4);
-	const __m256i highNybbleBitmasked				 = _mm256_and_si256(highNybbleBits, _mm256_set1_epi8(0x0F));
-	const __m256i highNybbleNegativeBitCount = _mm256_shuffle_epi8(highBitsLookupTable, highNybbleBitmasked);
-	const __m256i sadCountVector						 = _mm256_sad_epu8(lowNybbleBitCount, highNybbleNegativeBitCount);
-	// todo: try keeping nybble counts seperate, shifting both to be in the lower 128 bit regs, and performing separate
-	// hadds, and extracting out values at end from both nybble vectors.
+// uint8_t extractPopcnt(volatile __m256i vec) {
+// 	return _mm_popcnt_u64(_mm256_extract_epi64(vec, 0)) + _mm_popcnt_u64(_mm256_extract_epi64(vec, 1)) +
+// 				 _mm_popcnt_u64(_mm256_extract_epi64(vec, 2)) + _mm_popcnt_u64(_mm256_extract_epi64(vec, 3));
+// }
 
-	// TODO: try 4 extracts, see if it's faster
-	// shift and add, placing the final two 16-bit sums in the least significant bits of each 128-bit lane.
-	const __m256i laneVectorSums = _mm256_add_epi16(_mm256_slli_si256(sadCountVector, 4), sadCountVector);
-	const uint16_t finalSum			 = _mm256_extract_epi16(laneVectorSums, 0) + _mm256_extract_epi16(laneVectorSums, 1);
-	return finalSum;
-}
+// uint8_t storePopcnt(volatile __m256i vec) {
+// 	uint8_t unalignedBuffer[32 + 31];
+// 	uint8_t *alignedBuffer = (uint8_t *)((intptr_t)(unalignedBuffer + 31) & ~31);
+// 	_mm256_store_si256((__m256i *)alignedBuffer, vec);
+
+// 	uint64_t *bufferAs64_t = (uint64_t *)alignedBuffer;
+// 	return _mm_popcnt_u64(bufferAs64_t[0]) + _mm_popcnt_u64(bufferAs64_t[1]) + _mm_popcnt_u64(bufferAs64_t[2]) +
+// 				 _mm_popcnt_u64(bufferAs64_t[3]);
+// }
 
 
-inline uint_fast8_t awFmVectorPopcountQuadAdd(const __m256i occurrenceVector) {
-	const __m256i lowBitsLookupTable =
-			_mm256_setr_epi8(4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0, 4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0);
-	const __m256i highBitsLookupTable = _mm256_setr_epi8(-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0,
-			-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0);
+// inline uint_fast8_t awFmVectorPopcountShift(const __m256i occurrenceVector) {
+// 	const __m256i lowBitsLookupTable =
+// 			_mm256_setr_epi8(4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0, 4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0);
+// 	const __m256i highBitsLookupTable = _mm256_setr_epi8(-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0,
+// 			-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0);
 
-	const __m256i lowNybbleBitmasked				 = _mm256_and_si256(occurrenceVector, _mm256_set1_epi8(0x0F));
-	const __m256i lowNybbleBitCount					 = _mm256_shuffle_epi8(lowBitsLookupTable, lowNybbleBitmasked);
-	const __m256i highNybbleBits						 = _mm256_srli_si256(occurrenceVector, 4);
-	const __m256i highNybbleBitmasked				 = _mm256_and_si256(highNybbleBits, _mm256_set1_epi8(0x0F));
-	const __m256i highNybbleNegativeBitCount = _mm256_shuffle_epi8(highBitsLookupTable, highNybbleBitmasked);
-	const __m256i sadCountVector						 = _mm256_sad_epu8(lowNybbleBitCount, highNybbleNegativeBitCount);
-	// todo: try keeping nybble counts seperate, shifting both to be in the lower 128 bit regs, and performing separate
-	// hadds, and extracting out values at end from both nybble vectors.
+// 	const __m256i lowNybbleBitmasked				 = _mm256_and_si256(occurrenceVector, _mm256_set1_epi8(0x0F));
+// 	const __m256i lowNybbleBitCount					 = _mm256_shuffle_epi8(lowBitsLookupTable, lowNybbleBitmasked);
+// 	const __m256i highNybbleBits						 = _mm256_srli_si256(occurrenceVector, 4);
+// 	const __m256i highNybbleBitmasked				 = _mm256_and_si256(highNybbleBits, _mm256_set1_epi8(0x0F));
+// 	const __m256i highNybbleNegativeBitCount = _mm256_shuffle_epi8(highBitsLookupTable, highNybbleBitmasked);
+// 	const __m256i sadCountVector						 = _mm256_sad_epu8(lowNybbleBitCount, highNybbleNegativeBitCount);
+// 	// todo: try keeping nybble counts seperate, shifting both to be in the lower 128 bit regs, and performing separate
+// 	// hadds, and extracting out values at end from both nybble vectors.
 
-	// TODO: try 4 extracts, see if it's faster
-	// shift and add, placing the final two 16-bit sums in the least significant bits of each 128-bit lane.
-	const uint16_t finalSum = _mm256_extract_epi16(sadCountVector, 0) + _mm256_extract_epi16(sadCountVector, 1) +
-														_mm256_extract_epi16(sadCountVector, 2) + _mm256_extract_epi16(sadCountVector, 3);
-	return finalSum;
-}
-
-inline uint_fast8_t mulaCount(__m256i v) {
-	__m256i lookup =
-			_mm256_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
-	__m256i low_mask	= _mm256_set1_epi8(0x0f);
-	__m256i lo				= _mm256_and_si256(v, low_mask);
-	__m256i hi				= _mm256_and_si256(_mm256_srli_epi32(v, 4), low_mask);
-	__m256i popcnt1		= _mm256_shuffle_epi8(lookup, lo);
-	__m256i popcnt2		= _mm256_shuffle_epi8(lookup, hi);
-	__m256i total			= _mm256_add_epi8(popcnt1, popcnt2);
-	__m256i quadSum		= _mm256_sad_epu8(total, _mm256_setzero_si256());
-	uint16_t finalSum = _mm256_extract_epi16(quadSum, 0) + _mm256_extract_epi16(quadSum, 1) +
-											_mm256_extract_epi16(quadSum, 2) + _mm256_extract_epi16(quadSum, 3);
-	return finalSum;
-}
+// 	// TODO: try 4 extracts, see if it's faster
+// 	// shift and add, placing the final two 16-bit sums in the least significant bits of each 128-bit lane.
+// 	const __m256i laneVectorSums = _mm256_add_epi16(_mm256_slli_si256(sadCountVector, 4), sadCountVector);
+// 	const uint16_t finalSum			 = _mm256_extract_epi16(laneVectorSums, 0) + _mm256_extract_epi16(laneVectorSums, 1);
+// 	return finalSum;
+// }
 
 
-void parseArgs(int argc, char **argv) {
-	int option = 0;
-	while((option = getopt(argc, argv, "l:o:")) != -1) {
-		printf("option: %c ", option);
-		switch(option) {
+// inline uint_fast8_t awFmVectorPopcountQuadAdd(const __m256i occurrenceVector) {
+// 	const __m256i lowBitsLookupTable =
+// 			_mm256_setr_epi8(4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0, 4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0);
+// 	const __m256i highBitsLookupTable = _mm256_setr_epi8(-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0,
+// 			-4, -3, -3, -2, -3, -2, -2, -1, -3, -2, -2, -1, -2, -1, -1, 0);
 
-			case 'l':
-				sscanf(optarg, "%zu", &length);
-				printf("sequence length: dbSequenceLength\n");
-				break;
-			case 'o': sscanf(optarg, "%zu", &offset); break;
-		}
-	}
-}
+// 	const __m256i lowNybbleBitmasked				 = _mm256_and_si256(occurrenceVector, _mm256_set1_epi8(0x0F));
+// 	const __m256i lowNybbleBitCount					 = _mm256_shuffle_epi8(lowBitsLookupTable, lowNybbleBitmasked);
+// 	const __m256i highNybbleBits						 = _mm256_srli_si256(occurrenceVector, 4);
+// 	const __m256i highNybbleBitmasked				 = _mm256_and_si256(highNybbleBits, _mm256_set1_epi8(0x0F));
+// 	const __m256i highNybbleNegativeBitCount = _mm256_shuffle_epi8(highBitsLookupTable, highNybbleBitmasked);
+// 	const __m256i sadCountVector						 = _mm256_sad_epu8(lowNybbleBitCount, highNybbleNegativeBitCount);
+// 	// todo: try keeping nybble counts seperate, shifting both to be in the lower 128 bit regs, and performing separate
+// 	// hadds, and extracting out values at end from both nybble vectors.
 
+// 	// TODO: try 4 extracts, see if it's faster
+// 	// shift and add, placing the final two 16-bit sums in the least significant bits of each 128-bit lane.
+// 	const uint16_t finalSum = _mm256_extract_epi16(sadCountVector, 0) + _mm256_extract_epi16(sadCountVector, 1) +
+// 														_mm256_extract_epi16(sadCountVector, 2) + _mm256_extract_epi16(sadCountVector, 3);
+// 	return finalSum;
+// }
 
-int main(int argc, char **argv) {
-	srand(time(NULL));
-
-
-	parseArgs(argc, argv);
-
-	if(length == 0) {
-		printf("error: length is required, and must not be 0.\n");
-		exit(EXIT_FAILURE);
-	}
-
-	uint8_t *buffer = malloc(1L << 30L);
-
-
-	size_t accumulator = 0;
-	size_t acc2				 = 0;
-
-
-	clock_t beforeMula = clock();
-
-	for(size_t i = 0; i < length; i++) {
-		// printf("q\n");
-		uint8_t *vecPtr = buffer + offset;
-		__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
-		accumulator += mulaCount(vec);
-		acc2++;
-	}
-	clock_t afterMula		= clock();
-	clock_t beforeShift = clock();
+// inline uint_fast8_t mulaCount(__m256i v) {
+// 	__m256i lookup =
+// 			_mm256_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+// 	__m256i low_mask	= _mm256_set1_epi8(0x0f);
+// 	__m256i lo				= _mm256_and_si256(v, low_mask);
+// 	__m256i hi				= _mm256_and_si256(_mm256_srli_epi32(v, 4), low_mask);
+// 	__m256i popcnt1		= _mm256_shuffle_epi8(lookup, lo);
+// 	__m256i popcnt2		= _mm256_shuffle_epi8(lookup, hi);
+// 	__m256i total			= _mm256_add_epi8(popcnt1, popcnt2);
+// 	__m256i quadSum		= _mm256_sad_epu8(total, _mm256_setzero_si256());
+// 	uint16_t finalSum = _mm256_extract_epi16(quadSum, 0) + _mm256_extract_epi16(quadSum, 1) +
+// 											_mm256_extract_epi16(quadSum, 2) + _mm256_extract_epi16(quadSum, 3);
+// 	return finalSum;
+// }
 
 
-	for(size_t i = 0; i < length; i++) {
-		// printf("q\n");
-		uint8_t *vecPtr = buffer + offset;
-		__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
-		accumulator += awFmVectorPopcountShift(vec);
-		acc2++;
-	}
-	clock_t afterShift = clock();
+// void parseArgs(int argc, char **argv) {
+// 	int option = 0;
+// 	while((option = getopt(argc, argv, "l:o:")) != -1) {
+// 		printf("option: %c ", option);
+// 		switch(option) {
+
+// 			case 'l':
+// 				sscanf(optarg, "%zu", &length);
+// 				printf("sequence length: dbSequenceLength\n");
+// 				break;
+// 			case 'o': sscanf(optarg, "%zu", &offset); break;
+// 		}
+// 	}
+// }
 
 
-	clock_t beforeQuad = clock();
-
-	printf("length: %zu\n", length);
-	for(size_t i = 0; i < length; i++) {
-		// printf("s\n");
-		uint8_t *vecPtr = buffer + offset;
-		__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
-		accumulator += awFmVectorPopcountQuadAdd(vec);
-		acc2++;
-	}
-	clock_t afterQuad = clock();
+// int main(int argc, char **argv) {
+// 	srand(time(NULL));
 
 
-	// store
-	clock_t beforeStore = clock();
+// 	parseArgs(argc, argv);
 
-	printf("length: %zu\n", length);
-	uint8_t *vecPtr = buffer + offset;
-	__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
-	for(size_t i = 0; i < length; i++) {
-		// printf("s\n");
-		accumulator += storePopcnt(vec);
-		acc2++;
-	}
-	clock_t afterStore = clock();
+// 	if(length == 0) {
+// 		printf("error: length is required, and must not be 0.\n");
+// 		exit(EXIT_FAILURE);
+// 	}
 
-	// extract
-	clock_t beforeExtract = clock();
-
-	printf("length: %zu\n", length);
-	for(size_t i = 0; i < length; i++) {
-		// printf("s\n");
-		accumulator += extractPopcnt(vec);
-		acc2++;
-	}
-	clock_t afterExtract = clock();
+// 	uint8_t *buffer = malloc(1L << 30L);
 
 
-	printf("acc2: %zu\n", acc2);
-	acc2 = 0;
+// 	size_t accumulator = 0;
+// 	size_t acc2				 = 0;
 
-	size_t shiftTicks		= (afterShift - beforeShift);
-	size_t quadTicks		= (afterQuad - beforeQuad);
-	size_t mulaTicks		= (afterMula - beforeMula);
-	size_t extractTicks = (afterExtract - beforeExtract);
-	size_t storeTicks		= (afterStore - beforeStore);
-	printf("results: \nShift: \t\t%zu\nQuad: \t\t%zu\nMula: \t\t%zu\nextract:\t%zu\nstore:\t\t%zu\naccu: %zu\n",
-			shiftTicks, quadTicks, mulaTicks, extractTicks, storeTicks, accumulator);
-}
+
+// 	clock_t beforeMula = clock();
+
+// 	for(size_t i = 0; i < length; i++) {
+// 		// printf("q\n");
+// 		uint8_t *vecPtr = buffer + offset;
+// 		__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
+// 		accumulator += mulaCount(vec);
+// 		acc2++;
+// 	}
+// 	clock_t afterMula		= clock();
+// 	clock_t beforeShift = clock();
+
+
+// 	for(size_t i = 0; i < length; i++) {
+// 		// printf("q\n");
+// 		uint8_t *vecPtr = buffer + offset;
+// 		__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
+// 		accumulator += awFmVectorPopcountShift(vec);
+// 		acc2++;
+// 	}
+// 	clock_t afterShift = clock();
+
+
+// 	clock_t beforeQuad = clock();
+
+// 	printf("length: %zu\n", length);
+// 	for(size_t i = 0; i < length; i++) {
+// 		// printf("s\n");
+// 		uint8_t *vecPtr = buffer + offset;
+// 		__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
+// 		accumulator += awFmVectorPopcountQuadAdd(vec);
+// 		acc2++;
+// 	}
+// 	clock_t afterQuad = clock();
+
+
+// 	// store
+// 	clock_t beforeStore = clock();
+
+// 	printf("length: %zu\n", length);
+// 	uint8_t *vecPtr = buffer + offset;
+// 	__m256i vec			= _mm256_loadu_si256((__m256i *)vecPtr);
+// 	for(size_t i = 0; i < length; i++) {
+// 		// printf("s\n");
+// 		accumulator += storePopcnt(vec);
+// 		acc2++;
+// 	}
+// 	clock_t afterStore = clock();
+
+// 	// extract
+// 	clock_t beforeExtract = clock();
+
+// 	printf("length: %zu\n", length);
+// 	for(size_t i = 0; i < length; i++) {
+// 		// printf("s\n");
+// 		accumulator += extractPopcnt(vec);
+// 		acc2++;
+// 	}
+// 	clock_t afterExtract = clock();
+
+
+// 	printf("acc2: %zu\n", acc2);
+// 	acc2 = 0;
+
+// 	size_t shiftTicks		= (afterShift - beforeShift);
+// 	size_t quadTicks		= (afterQuad - beforeQuad);
+// 	size_t mulaTicks		= (afterMula - beforeMula);
+// 	size_t extractTicks = (afterExtract - beforeExtract);
+// 	size_t storeTicks		= (afterStore - beforeStore);
+// 	printf("results: \nShift: \t\t%zu\nQuad: \t\t%zu\nMula: \t\t%zu\nextract:\t%zu\nstore:\t\t%zu\naccu: %zu\n",
+// 			shiftTicks, quadTicks, mulaTicks, extractTicks, storeTicks, accumulator);
+// }

--- a/test/suffixArrayCompressionTests/makefile
+++ b/test/suffixArrayCompressionTests/makefile
@@ -1,5 +1,14 @@
-TEST_SRC	= saTest.c
-SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	=  -O0 -std=c11 -fsanitize=address -Wall -mtune=native -g -fopenmp -ldivsufsort64 -lfastavector -mavx2 -L../../lib/libdivsufsort/build/lib
-bwtTest: $(SRC)
-	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)
+TEST_SRC = saTest.c
+SRC = $(wildcard ../../src/*.c)
+
+CFLAGS = -std=c11 -fsanitize=address -Wall -mtune=native -fopenmp -mavx2 -O0 -g
+LDLIBS = ../../lib/FastaVector/build/libfastavector_static.a ../../lib/libdivsufsort/build/lib/libdivsufsort64.a
+
+EXE = saTest.out
+
+backtraceTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)


### PR DESCRIPTION
This change separates the alphabet "AwFmAlphabetNucleotide" into "AwFmAlphabetDna" and "AwFmAlpahbetRna". This allows the library to easily deal with RNA sequences (previously, the letter 'u' was considered an ambiguity or illegal character), while also keeping track of what kind of sequence the index was built from. 

This change also changes the test makefiles to allow for easier builds on systems where the helper libraries are not installed globally.