### PR TITLE
remove broken auto submodule init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,6 @@ project(
 set(CMAKE_C_STANDARD 17)
 
 
-add_custom_target(
-    update_submodules
-    COMMAND ${CMAKE_COMMAND} -E echo "Updating submodules..."
-    COMMAND git submodule update --init --recursive
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-
 #add support for OpenMP
 find_package(OpenMP REQUIRED)
 if(OpenMP_FOUND)


### PR DESCRIPTION
I can't seem to get cmake to understand the idea of initing the submodules before trying to use them, so we'll just remove it and make the user manually init the submodules