### PR TITLE
fix restrict keyword for cpp-compliance

### DIFF
--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -533,7 +533,7 @@ enum AwFmReturnCode awFmGetHeaderStringFromSequenceNumber(
  *    Number of positions in the given range if the range is valid (startPtr < endPtr),
  *      or 0 otherwise, as that would imply that no instances of that kmer were found.
  */
-size_t awFmSearchRangeLength(const struct AwFmSearchRange *restrict const range);
+size_t awFmSearchRangeLength(const struct AwFmSearchRange *_RESTRICT_ const range);
 
 
 /*


### PR DESCRIPTION
oops, missed a restrict. this will fix it so that AwFm works with g++ or other cpp compilers.