### PR TITLE
Fix fasta headers

### DIFF
--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -367,6 +367,14 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 			awFmDeallocIndex(indexData);
 			return AwFmAllocationFailure;
 		}
+
+		elementsRead = fread(&fastaVector->header.charData, sizeof(char), fastaVectorHeaderLength, fileHandle);
+		if(elementsRead != fastaVectorHeaderLength) {
+			fclose(fileHandle);
+			awFmDeallocIndex(indexData);
+			return AwFmAllocationFailure;
+		}
+
 		fastaVector->metadata.data =
 				realloc(fastaVector->metadata.data, fastaVectorMetadataLength * sizeof(struct FastaVectorMetadata));
 		if(!fastaVector->metadata.data) {
@@ -374,6 +382,14 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 			awFmDeallocIndex(indexData);
 			return AwFmAllocationFailure;
 		}
+
+		elementsRead = fread(&fastaVector->metadata.data, sizeof(struct FastaVectorMetadata), fastaVectorMetadataLength, fileHandle);
+		if(elementsRead != fastaVectorMetadataLength) {
+			fclose(fileHandle);
+			awFmDeallocIndex(indexData);
+			return AwFmAllocationFailure;
+		}
+
 		fastaVector->header.count			 = fastaVectorHeaderLength;
 		fastaVector->header.capacity	 = fastaVectorHeaderLength;
 		fastaVector->metadata.count		 = fastaVectorMetadataLength;

--- a/src/AwFmFile.c
+++ b/src/AwFmFile.c
@@ -343,6 +343,9 @@ enum AwFmReturnCode awFmReadIndexFromFile(
 
 		// free the sequence buffer in the fastaVector, since it won't be used here
 		fastaVectorStringDealloc(&fastaVector->sequence);
+		fastaVector->sequence.charData = NULL;
+		fastaVector->sequence.capacity = 0;
+		fastaVector->sequence.count = 0;
 
 		indexData->fastaVector = fastaVector;
 		size_t fastaVectorHeaderLength;


### PR DESCRIPTION
This patch fixes an issue with the FastaVector's metadata and header data. Previously, while the lengths of these two pieces of data were loaded when an AwFmIndex built from a fasta was loaded from file, but the actual data was never read. Now the data should be read correctly, and you can now retrieve both the headers and the positional metadata from the fastaVector struct.