### PR TITLE
Fix cmake static files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ set(
         PUBLIC_H_FILES
 
         src/AwFmIndex.h
+        lib/libdivsufsort/build/include/divsufsort64.h
+        lib/FastaVector/src/FastaVector.h
+        lib/FastaVector/src/FastaVectorMetadataVector.h
+        lib/FastaVector/src/FastaVectorString.h
 )
 
 set(
@@ -73,6 +77,38 @@ set_target_properties(
         PUBLIC_HEADER ${PUBLIC_H_FILES}
 )
 
+add_custom_target(
+    copy_headers
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/include/AWFMIndex
+)
+
+foreach(HEADER ${PUBLIC_H_FILES})
+    add_custom_command(
+        TARGET copy_headers
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/${HEADER}
+                ${CMAKE_CURRENT_BINARY_DIR}/build
+    )
+endforeach()
+
+
+#copy the libdivsufsort and fastavector static libs to the build director
+add_custom_command(
+    TARGET awfmindex_static
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_FILE:divsufsort64>
+            $<TARGET_FILE_DIR:awfmindex_static>
+)
+add_custom_command(
+    TARGET awfmindex_static
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_FILE:divsufsort64>
+            $<TARGET_FILE:fastavector_static>
+            $<TARGET_FILE_DIR:awfmindex_static>
+)
+
 target_compile_options(
         awfmindex_static
         PRIVATE
@@ -104,6 +140,7 @@ install(
 # ------------
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/)
+add_dependencies(awfmindex_static copy_headers)
 
 # FastaVector
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,12 @@ endif()
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY build)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY build)
 
+
+#PUBLIC_H_FILES is missing divsufsort64.h, because it doesn't exist until after divsufsort is built
 set(
         PUBLIC_H_FILES
 
         src/AwFmIndex.h
-        lib/libdivsufsort/build/include/divsufsort64.h
         lib/FastaVector/src/FastaVector.h
         lib/FastaVector/src/FastaVectorMetadataVector.h
         lib/FastaVector/src/FastaVectorString.h
@@ -70,26 +71,24 @@ add_library(
         ${C_FILES}
 )
 
+# Set public headers for awfmindex_static
 set_target_properties(
-        awfmindex_static awfmindex
+    awfmindex_static
+    PROPERTIES
+    PUBLIC_HEADER "${PUBLIC_H_FILES}"
+)
 
-        PROPERTIES
-        PUBLIC_HEADER ${PUBLIC_H_FILES}
+# Set public headers for awfmindex
+set_target_properties(
+    awfmindex
+    PROPERTIES
+    PUBLIC_HEADER "${PUBLIC_H_FILES}"
 )
 
 add_custom_target(
     copy_headers
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/include/AWFMIndex
 )
-
-foreach(HEADER ${PUBLIC_H_FILES})
-    add_custom_command(
-        TARGET copy_headers
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_CURRENT_SOURCE_DIR}/${HEADER}
-                ${CMAKE_CURRENT_BINARY_DIR}/build
-    )
-endforeach()
 
 
 #copy the libdivsufsort and fastavector static libs to the build director
@@ -140,6 +139,24 @@ install(
 # ------------
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/)
+
+# Custom target for building submodules
+add_custom_target(build_submodule
+    COMMENT "Building submodules"
+)
+
+
+# Custom command to copy public headers after building submodules
+foreach(HEADER ${PUBLIC_H_FILES})
+    add_custom_command(
+        TARGET build_submodule  # Add dependency on build_submodule
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/${HEADER}
+                ${CMAKE_CURRENT_BINARY_DIR}/build
+    )
+endforeach()
+
+add_dependencies(awfmindex_static build_submodule)
 add_dependencies(awfmindex_static copy_headers)
 
 # FastaVector
@@ -169,3 +186,22 @@ target_include_directories(
 
 target_link_libraries(awfmindex_static PRIVATE divsufsort64)
 target_link_libraries(awfmindex PRIVATE divsufsort64)
+
+
+
+# Custom target for building submodules
+add_custom_target(build_divsufsort
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/lib/
+    COMMENT "Building submodule"
+)
+
+# Custom command to move the divsufsort64.h file after the end of the build
+add_custom_command(
+        TARGET awfmindex_static POST_BUILD # Add dependency on build_submodule
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_BINARY_DIR}/lib/libdivsufsort/include/divsufsort64.h
+        ${CMAKE_CURRENT_BINARY_DIR}/build/
+)
+
+# Add a dependency on build_submodule
+add_dependencies(awfmindex_static build_divsufsort)

--- a/test/sharedLibTest/awfmiTest.c
+++ b/test/sharedLibTest/awfmiTest.c
@@ -1,0 +1,31 @@
+#include "AwFmIndex.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    struct AwFmIndex *index;
+
+    struct AwFmIndexConfiguration config;
+    config.suffixArrayCompressionRatio = 2;
+	config.kmerLengthInSeedTable = 2;
+	config.alphabetType = AwFmAlphabetDna;
+	config.keepSuffixArrayInMemory = true;
+	config.storeOriginalSequence = false;
+
+    enum AwFmReturnCode awfmrc = awFmCreateIndexFromFasta(&index,& config, "test.fa", "output.awfmi");
+    
+    if (awFmReturnCodeIsFailure(awfmrc))
+    {
+        printf("ERROR: createIndex returned error code %u\n", awfmrc);
+        exit(-1);
+    }
+    else
+    {
+        printf("createIndex successful\n");
+    }
+
+    awFmDeallocIndex(index);
+}

--- a/test/sharedLibTest/makefile
+++ b/test/sharedLibTest/makefile
@@ -1,0 +1,14 @@
+TEST_SRC = awfmiTest.c
+
+CFLAGS = -std=c11 -Wall -mtune=native -fopenmp -mavx2 -O3
+LDLIBS = -lawfmindex
+
+EXE = sharedLibTest.out
+
+sharedLibTest: $(TEST_SRC)
+	if [ -z "$$LD_LIBRARY_PATH" ]; then export LD_LIBRARY_PATH=/usr/local/lib; fi
+	gcc $(TEST_SRC)  -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/sharedLibTest/test.fa
+++ b/test/sharedLibTest/test.fa
@@ -1,0 +1,2 @@
+>test 1 header
+test1sequencedataagasfnlawebrfilqawhbefrilahwbseflikhabsdlfikhbas

--- a/test/staticLibTest/awfmiTest.c
+++ b/test/staticLibTest/awfmiTest.c
@@ -1,0 +1,32 @@
+#include "AwFmIndex.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+
+    struct AwFmIndex *index;
+
+    struct AwFmIndexConfiguration config;
+    config.suffixArrayCompressionRatio = 2;
+	config.kmerLengthInSeedTable = 2;
+	config.alphabetType = AwFmAlphabetDna;
+	config.keepSuffixArrayInMemory = true;
+	config.storeOriginalSequence = false;
+
+    enum AwFmReturnCode awfmrc = awFmCreateIndexFromFasta(&index,& config, "test.fa", "output.awfmi");
+    
+    if (awFmReturnCodeIsFailure(awfmrc))
+    {
+        printf("ERROR: createIndex returned error code %u\n", awfmrc);
+        exit(-1);
+    }
+    else
+    {
+        printf("createIndex successful\n");
+    }
+
+    awFmDeallocIndex(index);
+}

--- a/test/staticLibTest/makefile
+++ b/test/staticLibTest/makefile
@@ -1,0 +1,14 @@
+TEST_SRC = awfmiTest.c
+
+CFLAGS = -std=c11 -Wall -mtune=native -fopenmp -mavx2 -O3
+LDFLAGS = -L../../build
+LDLIBS = -lawfmindex
+
+EXE = staticLibTest.out
+
+staticLibTest: $(TEST_SRC)
+	gcc $(TEST_SRC) $(LDFLAGS)  -o $(EXE) $(CFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(EXE)

--- a/test/staticLibTest/test.fa
+++ b/test/staticLibTest/test.fa
@@ -1,0 +1,2 @@
+>test 1 header
+test1sequencedataagasfnlawebrfilqawhbefrilahwbseflikhabsdlfikhbas


### PR DESCRIPTION
This PR ensures that the cmake and make build systems generate the public headers and all static libs to the build/ directory. This happens in the cmake build
```
cmake .
make
```

and the legacy static build
```
make -f Makefile_legacy static
```

This PR also adds tests that attempt to use the static library in the build directory, and the shared library, defaulting to the traditional /usr/local/ install location.