### PR TITLE
change backwardSearch signature to clarify that it takes a letter Idx

### DIFF
--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -462,10 +462,10 @@ struct AwFmSearchRange awFmCreateInitialQueryRangeFromChar(
  *    index: AwFmIndex struct to search
  *    range: range in the BWT that corresponds to the implicit kmer that is about to be extended.
  *      this acts as an out-parameter, and will update to the newly extended range once finished.
- *    letter: letter of the prefix or suffix character.
+ *    letterIndex: letter index of the prefix or suffix character, between 0 and 3.
  */
 void awFmNucleotideIterativeStepBackwardSearch(
-		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter);
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letterIndex);
 
 
 /*
@@ -479,10 +479,10 @@ void awFmNucleotideIterativeStepBackwardSearch(
  *    index: AwFmIndex struct to search
  *    range: range in the BWT that corresponds to the implicit kmer that is about to be extended.
  *      this acts as an out-parameter, and will update to the newly extended range once finished.
- *    letter: letter of the prefix or suffix character.
+ *    letterIndex: letter index of the suffix character, between 0 and 19.
  */
 void awFmAminoIterativeStepBackwardSearch(
-		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter);
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letterIndex);
 
 
 /*

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -42,20 +42,20 @@ struct AwFmSearchRange awFmCreateInitialQueryRangeFromChar(
 
 
 void awFmNucleotideIterativeStepBackwardSearch(
-		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter) {
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letterIndex) {
 
 	// query for the start pointer
 	uint64_t queryPosition				 = range->startPtr - 1;
-	const uint64_t letterPrefixSum = index->prefixSums[letter];
+	const uint64_t letterPrefixSum = index->prefixSums[letterIndex];
 
 	uint64_t blockIndex				 = awFmGetBlockIndexFromGlobalPosition(queryPosition);
 	uint8_t localQueryPosition = awFmGetBlockQueryPositionFromGlobalPosition(queryPosition);
 
 	// before needing the bit vectors, we can figure out if they sentinel character will be added.
 	uint64_t newStartPointer = letterPrefixSum;
-	uint64_t baseOccurrence	 = index->bwtBlockList.asNucleotide[blockIndex].baseOccurrences[letter];
+	uint64_t baseOccurrence	 = index->bwtBlockList.asNucleotide[blockIndex].baseOccurrences[letterIndex];
 	AwFmSimdVec256 occurrenceVector =
-			awFmMakeNucleotideOccurrenceVector(&(index->bwtBlockList.asNucleotide[blockIndex]), letter);
+			awFmMakeNucleotideOccurrenceVector(&(index->bwtBlockList.asNucleotide[blockIndex]), letterIndex);
 
 	uint_fast16_t vectorPopcount = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 	newStartPointer += vectorPopcount + baseOccurrence;
@@ -78,8 +78,8 @@ void awFmNucleotideIterativeStepBackwardSearch(
 	// we can subtract it here to kill time before needing the block from memory
 	uint64_t newEndPointer = letterPrefixSum - 1;
 
-	baseOccurrence	 = index->bwtBlockList.asNucleotide[blockIndex].baseOccurrences[letter];
-	occurrenceVector = awFmMakeNucleotideOccurrenceVector(&(index->bwtBlockList.asNucleotide[blockIndex]), letter);
+	baseOccurrence	 = index->bwtBlockList.asNucleotide[blockIndex].baseOccurrences[letterIndex];
+	occurrenceVector = awFmMakeNucleotideOccurrenceVector(&(index->bwtBlockList.asNucleotide[blockIndex]), letterIndex);
 	vectorPopcount	 = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 
 	newEndPointer += vectorPopcount + baseOccurrence;
@@ -96,17 +96,17 @@ void awFmNucleotideIterativeStepBackwardSearch(
 
 
 void awFmAminoIterativeStepBackwardSearch(
-		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letter) {
+		const struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange *_RESTRICT_ const range, const uint8_t letterIndex) {
 
 	// query for the start pointer
 	uint64_t queryPosition				 = range->startPtr - 1;
-	const uint64_t letterPrefixSum = index->prefixSums[letter];
+	const uint64_t letterPrefixSum = index->prefixSums[letterIndex];
 
 	uint64_t blockIndex				 = awFmGetBlockIndexFromGlobalPosition(queryPosition);
 	uint8_t localQueryPosition = awFmGetBlockQueryPositionFromGlobalPosition(queryPosition);
-	uint64_t baseOccurrence		 = index->bwtBlockList.asAmino[blockIndex].baseOccurrences[letter];
+	uint64_t baseOccurrence		 = index->bwtBlockList.asAmino[blockIndex].baseOccurrences[letterIndex];
 	AwFmSimdVec256 occurrenceVector =
-			awFmMakeAminoAcidOccurrenceVector(&(index->bwtBlockList.asAmino[blockIndex]), letter);
+			awFmMakeAminoAcidOccurrenceVector(&(index->bwtBlockList.asAmino[blockIndex]), letterIndex);
 	uint16_t vectorPopcount	 = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 	uint64_t newStartPointer = letterPrefixSum + vectorPopcount + baseOccurrence;
 
@@ -125,8 +125,8 @@ void awFmAminoIterativeStepBackwardSearch(
 	blockIndex				 = awFmGetBlockIndexFromGlobalPosition(queryPosition);
 	localQueryPosition = awFmGetBlockQueryPositionFromGlobalPosition(queryPosition);
 
-	baseOccurrence	 = index->bwtBlockList.asAmino[blockIndex].baseOccurrences[letter];
-	occurrenceVector = awFmMakeAminoAcidOccurrenceVector(&(index->bwtBlockList.asAmino[blockIndex]), letter);
+	baseOccurrence	 = index->bwtBlockList.asAmino[blockIndex].baseOccurrences[letterIndex];
+	occurrenceVector = awFmMakeAminoAcidOccurrenceVector(&(index->bwtBlockList.asAmino[blockIndex]), letterIndex);
 	vectorPopcount	 = AwFmMaskedVectorPopcount(occurrenceVector, localQueryPosition);
 
 	const uint64_t newEndPointer = letterPrefixSum + vectorPopcount + baseOccurrence - 1;


### PR DESCRIPTION
Previously, the backwardSearch functions said that they take a "letter" which is easy to misconstrue as ascii. now, it is clear that it takes a letter index in the range of 0 to alphabetSize -1