### PR TITLE
fix issue where kmer lengths above 255 were causing undefined behavior.

### DIFF
--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -429,7 +429,7 @@ enum AwFmReturnCode awFmReadSequenceFromFile(const struct AwFmIndex *_RESTRICT_ 
  *    in the input query.
  */
 struct AwFmSearchRange awFmCreateInitialQueryRange(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const query, const uint8_t queryLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const query, const uint64_t queryLength);
 
 
 /*

--- a/src/AwFmParallelSearch.c
+++ b/src/AwFmParallelSearch.c
@@ -185,7 +185,7 @@ void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *_RESTRICT_ cons
 
 	for(size_t kmerIndex = threadBlockStartIndex; kmerIndex < threadBlockEndIndex; kmerIndex++) {
 		const struct AwFmKmerSearchData *searchData = &searchList->kmerSearchData[kmerIndex];
-		const uint8_t kmerLength	= searchData->kmerLength;
+		const uint64_t kmerLength	= searchData->kmerLength;
 		const char *kmerString		= searchData->kmerString;
 
 		const bool queryCanUseKmerTable = awFmQueryCanUseKmerTable(index, kmerString, kmerLength);
@@ -193,9 +193,9 @@ void parallelSearchFindKmerSeedsForBlock(const struct AwFmIndex *_RESTRICT_ cons
 		const uint64_t rangesIndex = kmerIndex - threadBlockStartIndex;
 
 		//these are used if the kmer is ineligible for using the kmerSeedTable
-		const uint8_t kmerStringNonSeededStart = kmerLength < index->config.kmerLengthInSeedTable?
+		const uint64_t kmerStringNonSeededStart = kmerLength < index->config.kmerLengthInSeedTable?
 			0: kmerLength - index->config.kmerLengthInSeedTable;
-		const uint8_t kmerStringNonSeededLength = kmerLength < index->config.kmerLengthInSeedTable?
+		const uint64_t kmerStringNonSeededLength = kmerLength < index->config.kmerLengthInSeedTable?
 			kmerLength: index->config.kmerLengthInSeedTable;
 
 		if(index->config.alphabetType != AwFmAlphabetAmino) {
@@ -225,7 +225,7 @@ void parallelSearchExtendKmersInBlock(const struct AwFmIndex *_RESTRICT_ const i
 		struct AwFmKmerSearchList *_RESTRICT_ const searchList, struct AwFmSearchRange *_RESTRICT_ const ranges,
 		const size_t threadBlockStartIndex, const size_t threadBlockEndIndex) {
 	bool hasActiveQueries					 = true;
-	uint8_t currentKmerLetterIndex = index->config.kmerLengthInSeedTable;
+	uint64_t currentKmerLetterIndex = index->config.kmerLengthInSeedTable;
 
 	while(hasActiveQueries) {
 		currentKmerLetterIndex++;
@@ -234,12 +234,12 @@ void parallelSearchExtendKmersInBlock(const struct AwFmIndex *_RESTRICT_ const i
 		for(size_t kmerIndex = threadBlockStartIndex; kmerIndex < threadBlockEndIndex; kmerIndex++) {
 			const uint64_t rangesIndex																 = kmerIndex - threadBlockStartIndex;
 			const struct AwFmKmerSearchData *_RESTRICT_ const searchData = &searchList->kmerSearchData[kmerIndex];
-			const uint8_t kmerLength																	 = searchData->kmerLength;
+			const uint64_t kmerLength																	 = searchData->kmerLength;
 			const char *kmerString																		 = searchData->kmerString;
 
 			if((kmerLength >= currentKmerLetterIndex) && awFmSearchRangeIsValid(&ranges[rangesIndex])) {
 				hasActiveQueries											= true;
-				const uint8_t currentQueryLetterIndex = kmerLength - currentKmerLetterIndex;
+				const uint64_t currentQueryLetterIndex = kmerLength - currentKmerLetterIndex;
 
 				if(index->config.alphabetType != AwFmAlphabetAmino) {
 					const uint8_t queryLetterIndex = awFmAsciiNucleotideToLetterIndex(kmerString[currentQueryLetterIndex]);

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -6,7 +6,7 @@
 
 
 struct AwFmSearchRange awFmCreateInitialQueryRange(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const query, const uint8_t queryLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const query, const uint64_t queryLength) {
 
 	uint8_t finalLetterIndexInQuery;
 	if(index->config.alphabetType != AwFmAlphabetAmino) {
@@ -422,9 +422,9 @@ inline uint8_t awFmAminoBacktraceReturnPreviousLetterIndex(
 
 
 inline void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
-		const uint8_t kmerLength, struct AwFmSearchRange *range) {
+		const uint64_t kmerLength, struct AwFmSearchRange *range) {
 
-	uint8_t indexInKmerString = kmerLength - 1;
+	uint64_t indexInKmerString = kmerLength - 1;
 	uint8_t queryLetterIndex	= awFmAsciiNucleotideToLetterIndex(kmer[indexInKmerString]);
 	range->startPtr						= index->prefixSums[queryLetterIndex];
 	range->endPtr							= index->prefixSums[queryLetterIndex + 1] - 1;
@@ -436,9 +436,9 @@ inline void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ con
 
 
 inline void awFmAminoNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
-		const uint8_t kmerLength, struct AwFmSearchRange *range) {
+		const uint64_t kmerLength, struct AwFmSearchRange *range) {
 
-	uint8_t indexInKmerString = kmerLength - 1;
+	uint64_t indexInKmerString = kmerLength - 1;
 	uint8_t queryLetterIndex	= awFmAsciiAminoAcidToLetterIndex(kmer[indexInKmerString]);
 	range->startPtr = index->prefixSums[queryLetterIndex], range->endPtr = index->prefixSums[queryLetterIndex + 1] - 1;
 

--- a/src/AwFmSearch.h
+++ b/src/AwFmSearch.h
@@ -86,7 +86,7 @@ bool awFmSingleKmerExists(
  *
  */
 void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
-		const uint8_t kmerLength, struct AwFmSearchRange *range);
+		const uint64_t kmerLength, struct AwFmSearchRange *range);
 
 
 /*
@@ -111,7 +111,7 @@ void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const inde
  *
  */
 void awFmAminoNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
-		const uint8_t kmerLength, struct AwFmSearchRange *range);
+		const uint64_t kmerLength, struct AwFmSearchRange *range);
 
 
 #endif /* end of include guard: AW_FM_INDEX_SEARCH_H */


### PR DESCRIPTION
some places, the kmer length or offset into the kmer were uint8_t's. For queries 256 or longer, this caused overflow and weird stuff happened.

This bug was caused by the query lengths being stored as uint8_t's in a few places internally. Now the lengths are (at a minimum) uint32_t's, allowing for an unnecessary 4 GiB long queries.