### PR TITLE
Fix remaining issues with queries longer than 255

### DIFF
--- a/src/AwFmCreate.c
+++ b/src/AwFmCreate.c
@@ -19,7 +19,7 @@ void setBwtAndPrefixSums(struct AwFmIndex *_RESTRICT_ const index, const size_t 
 		const uint8_t *_RESTRICT_ const sequence, const uint64_t *_RESTRICT_ const unsampledSuffixArray);
 
 void populateKmerSeedTableRecursive(struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange range,
-		uint8_t currentKmerLength, uint64_t currentKmerIndex, uint64_t letterIndexMultiplier);
+		size_t currentKmerLength, uint64_t currentKmerIndex, uint64_t letterIndexMultiplier);
 		
 void populateKmerSeedTable(struct AwFmIndex *_RESTRICT_ const index);
 
@@ -361,10 +361,10 @@ void populateKmerSeedTable(struct AwFmIndex *_RESTRICT_ const index) {
 
 
 void populateKmerSeedTableRecursive(struct AwFmIndex *_RESTRICT_ const index, struct AwFmSearchRange range,
-		uint8_t currentKmerLength, uint64_t currentKmerIndex, uint64_t letterIndexMultiplier) {
+		size_t currentKmerLength, uint64_t currentKmerIndex, uint64_t letterIndexMultiplier) {
 	const uint8_t alphabetSize = awFmGetAlphabetCardinality(index->config.alphabetType);
 
-	const uint8_t kmerLength = index->config.kmerLengthInSeedTable;
+	const size_t kmerLength = index->config.kmerLengthInSeedTable;
 
 	// base case
 	if(kmerLength == currentKmerLength) {

--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -349,7 +349,7 @@ void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *_RESTRICT_ const searc
 *					is stored on file, not in memory)
  */
 enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *_RESTRICT_ const index,
-		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads);
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint32_t numThreads);
 
 
 /*
@@ -380,7 +380,7 @@ enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *_RESTRICT_ 
  *                    will likely vary from system to system. Suggested default value is 4
  */
 void awFmParallelSearchCount(const struct AwFmIndex *_RESTRICT_ const index,
-		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads);
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint32_t numThreads);
 
 
 /*

--- a/src/AwFmIndex.h
+++ b/src/AwFmIndex.h
@@ -275,7 +275,7 @@ enum AwFmReturnCode awFmReadIndexFromFile(
  *    the given kmer does not exist in the database sequence.
  */
 struct AwFmSearchRange awFmFindSearchRangeForString(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength);
 
 
 /*

--- a/src/AwFmKmerTable.c
+++ b/src/AwFmKmerTable.c
@@ -6,12 +6,12 @@
 
 
 bool awFmQueryCanUseKmerTable(const struct AwFmIndex *_RESTRICT_ const index,
-	const char *_RESTRICT_ const kmer, const uint8_t kmerLength){
+	const char *_RESTRICT_ const kmer, const size_t kmerLength){
 
 	if (kmerLength < index->config.kmerLengthInSeedTable){
 		return false;
 	}
-	for(uint8_t letterIdx = kmerLength - index->config.kmerLengthInSeedTable; letterIdx < kmerLength; letterIdx++){
+	for(size_t letterIdx = kmerLength - index->config.kmerLengthInSeedTable; letterIdx < kmerLength; letterIdx++){
 		if(awFmLetterIsAmbiguous(kmer[letterIdx], index->config.alphabetType)){
 			return false;
 		}
@@ -22,11 +22,11 @@ bool awFmQueryCanUseKmerTable(const struct AwFmIndex *_RESTRICT_ const index,
 
 
 struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength) {
 
-	const uint8_t kmerSeedStartPosition = kmerLength - index->config.kmerLengthInSeedTable;
-	uint64_t kmerTableIndex							= 0;
-	for(int_fast16_t i = kmerSeedStartPosition; i < kmerLength; i++) {
+	const size_t kmerSeedStartPosition = kmerLength - index->config.kmerLengthInSeedTable;
+	size_t kmerTableIndex							= 0;
+	for(size_t i = kmerSeedStartPosition; i < kmerLength; i++) {
 		uint8_t letterIndex = awFmAsciiNucleotideToLetterIndex(kmer[i]);
 		kmerTableIndex			= (kmerTableIndex * AW_FM_NUCLEOTIDE_CARDINALITY) + letterIndex;
 	}
@@ -36,11 +36,11 @@ struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
 
 
 struct AwFmSearchRange awFmAminoKmerSeedRangeFromTable(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength) {
 
-	const uint8_t kmerSeedStartPosition = kmerLength - index->config.kmerLengthInSeedTable;
-	uint64_t kmerTableIndex							= 0;
-	for(int_fast16_t i = kmerSeedStartPosition; i < kmerLength; i++) {
+	const size_t kmerSeedStartPosition = kmerLength - index->config.kmerLengthInSeedTable;
+	size_t kmerTableIndex							= 0;
+	for(size_t i = kmerSeedStartPosition; i < kmerLength; i++) {
 		uint8_t letterIndex = awFmAsciiAminoAcidToLetterIndex(kmer[i]);
 		kmerTableIndex			= (kmerTableIndex * AW_FM_AMINO_CARDINALITY) + letterIndex;
 	}

--- a/src/AwFmKmerTable.h
+++ b/src/AwFmKmerTable.h
@@ -24,7 +24,7 @@
  *    Copy of the AwFmSearchRange containing the startPtr and endPtr for the kmer seed.
  */
 struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength);
 
 
 /*
@@ -45,7 +45,7 @@ struct AwFmSearchRange awFmNucleotideKmerSeedRangeFromTable(
  *    Copy of the AwFmSearchRange containing the startPtr and endPtr for the kmer seed.
  */
 struct AwFmSearchRange awFmAminoKmerSeedRangeFromTable(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint8_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength);
 
 
 /*
@@ -63,7 +63,7 @@ struct AwFmSearchRange awFmAminoKmerSeedRangeFromTable(
  *    true if the kmer is eligible for using the kmer seed table, or false otherwise.
  */
 bool awFmQueryCanUseKmerTable(const struct AwFmIndex *_RESTRICT_ const index,
-	const char *_RESTRICT_ const kmer, const uint8_t kmerLength);
+	const char *_RESTRICT_ const kmer, const size_t kmerLength);
 
 
 #endif /* end of include guard: AW_FM_KMER_TABLE_H */

--- a/src/AwFmOccurrence.h
+++ b/src/AwFmOccurrence.h
@@ -93,7 +93,7 @@ void awFmBlockPrefetch(
  *
  *  Inputs:
  *    blockList: blockList to be queried.
- *    bwtPosition: Position of the character to be returned.
+ *    localPosition: Position of the character to be returned.
  *
  *  Returns:
  *    letter at the bwtPosition in the specified blockList.
@@ -108,7 +108,7 @@ uint8_t awFmGetNucleotideLetterAtBwtPosition(const struct AwFmNucleotideBlock *b
  *
  *  Inputs:
  *    blockList: blockList to be queried.
- *    bwtPosition: Position of the character to be returned.
+ *    localPosition: Position of the character to be returned.
  *
  *  Returns:
  *    letter at the bwtPosition in the specified blockList.

--- a/src/AwFmParallelSearch.c
+++ b/src/AwFmParallelSearch.c
@@ -90,7 +90,7 @@ void awFmDeallocKmerSearchList(struct AwFmKmerSearchList *_RESTRICT_ const searc
 
 
 enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *_RESTRICT_ const index,
-		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads) {
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint32_t numThreads) {	
 
 	const uint32_t searchListCount = searchList->count;
 	enum AwFmReturnCode atomicReturnCode = AwFmSuccess;
@@ -134,7 +134,7 @@ enum AwFmReturnCode awFmParallelSearchLocate(const struct AwFmIndex *_RESTRICT_ 
 }
 
 void awFmParallelSearchCount(const struct AwFmIndex *_RESTRICT_ const index,
-		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint8_t numThreads) {
+		struct AwFmKmerSearchList *_RESTRICT_ const searchList, uint32_t numThreads) {
 
 	const uint32_t searchListCount = searchList->count;
 

--- a/src/AwFmSearch.c
+++ b/src/AwFmSearch.c
@@ -285,8 +285,8 @@ enum AwFmReturnCode awFmGetHeaderStringFromSequenceNumber(const struct AwFmIndex
 
 
 struct AwFmSearchRange awFmFindSearchRangeForString(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength) {
-	int8_t kmerLetterPosition = kmerLength - 1;
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength) {
+	size_t kmerLetterPosition = kmerLength - 1;
 	uint16_t bwtBlockWidth;
 	uint8_t kmerLetterIndex;
 
@@ -322,7 +322,7 @@ struct AwFmSearchRange awFmFindSearchRangeForString(
 
 
 bool awFmSingleKmerExists(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength) {
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength) {
 
 	struct AwFmSearchRange kmerRange = awFmFindSearchRangeForString(index, kmer, kmerLength);
 	return kmerRange.startPtr <= kmerRange.endPtr;

--- a/src/AwFmSearch.h
+++ b/src/AwFmSearch.h
@@ -62,7 +62,7 @@ size_t awFmAminoBacktraceBwtPosition(const struct AwFmIndex *_RESTRICT_ const in
  *      cannot be found in the database sequence.
  */
 bool awFmSingleKmerExists(
-		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const uint16_t kmerLength);
+		const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer, const size_t kmerLength);
 
 /*
  * Function:  awFmNucleotideNonSeededSearch
@@ -86,7 +86,7 @@ bool awFmSingleKmerExists(
  *
  */
 void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
-		const uint64_t kmerLength, struct AwFmSearchRange *range);
+		const size_t kmerLength, struct AwFmSearchRange *range);
 
 
 /*
@@ -111,7 +111,7 @@ void awFmNucleotideNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const inde
  *
  */
 void awFmAminoNonSeededSearch(const struct AwFmIndex *_RESTRICT_ const index, const char *_RESTRICT_ const kmer,
-		const uint64_t kmerLength, struct AwFmSearchRange *range);
+		const size_t kmerLength, struct AwFmSearchRange *range);
 
 
 #endif /* end of include guard: AW_FM_INDEX_SEARCH_H */


### PR DESCRIPTION
This PR is a companion to the previous one. There were still a few places in the codebase where kmer length or position were being considered either uint8_t's or uint16_t's. This change makes all kmer length and position variables type size_t. Kmers of all lengths should now be supported.

Additionally, the argument for number of threads has now been updated to uint32_t, allowing for more than 255 threads.